### PR TITLE
fix(wrangler): add build.upload

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,3 +13,6 @@ kv_namespaces = [
 
 [build]
 command = "yarn install && yarn build"
+
+[build.upload]
+format = "service-worker"


### PR DESCRIPTION
When I tried to publish, I encountered this error:
```sh
$wrangler publish
Error: missing field `upload`
```

I don't know if this was because I misconfigured something.
This commit fixed this error ~~on my computer~~.