### PR TITLE
fix(content parsing): less strict with type judging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ async function handlePostOrPut(request, isPut) {
 
   // parse formdata
   let form = {}
-  if (contentType.includes("multipart/form-data")) {
+  if (contentType.includes("form")) {
     // because cloudflare runtime treat all formdata part as strings thus corrupting binary data,
     // we need to manually parse formdata
     const uint8Array = await request.arrayBuffer()


### PR DESCRIPTION
When I used the latest code to publish, I encountered this problem on deployed web page:

```
{
    "readyState": 4,
    "responseText": "bad usage, please use 'multipart/form-data' instead of application/x-www-form-urlencoded; charset=UTF-8\n",
    "status": 400,
    "statusText": "error"
}
```

This commit can fix my problem, but I don't know whether it is not strict enough.