### PR TITLE
[Fix] import Buffer explicitly

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,4 +1,5 @@
 import { WorkerError } from "./common.js"
+import { Buffer } from 'node:buffer'
 
 // Encoding function
 export function encodeBasicAuth(username, password) {


### PR DESCRIPTION
When using basic auth, after input username and password, the server will response `Error 500, Buffer is not defined`.

wrangler.toml did add nodejs compact flag, so just need to import Buffer explicitly.

related docs:
https://developers.cloudflare.com/workers/runtime-apis/nodejs/buffer/