### PR TITLE
fix(metadata): compatibility with old kv records

### DIFF
--- a/src/handlers/handleDelete.js
+++ b/src/handlers/handleDelete.js
@@ -7,7 +7,7 @@ export async function handleDelete(request, env, ctx) {
   if (item.value === null) {
     throw new WorkerError(404, `paste of name '${short}' not found`)
   } else {
-    if (passwd !== item.metadata.passwd) {
+    if (passwd !== item.metadata?.passwd) {
       throw new WorkerError(403, `incorrect password for paste '${short}`)
     } else {
       await env.PB.delete(short)

--- a/src/handlers/handleRead.js
+++ b/src/handlers/handleRead.js
@@ -16,7 +16,7 @@ function pasteCacheHeader(env) {
 }
 
 function lastModifiedHeader(paste) {
-  const lastModified = paste.metadata.lastModified
+  const lastModified = paste.metadata?.lastModified
   return lastModified ? { "last-modified": new Date(lastModified).toGMTString() } : {}
 }
 
@@ -53,7 +53,7 @@ export async function handleGet(request, env, ctx) {
   }
 
   // check `if-modified-since`
-  const pasteLastModified = item.metadata.lastModified
+  const pasteLastModified = item.metadata?.lastModified
   const headerModifiedSince = request.headers.get("if-modified-since")
   if (pasteLastModified && headerModifiedSince) {
     let pasteLastModifiedMs = Date.parse(pasteLastModified)
@@ -68,7 +68,7 @@ export async function handleGet(request, env, ctx) {
   }
 
   // determine filename with priority: url path > meta
-  const returnFilename = filename || item.metadata.filename
+  const returnFilename = filename || item.metadata?.filename
 
   // handle URL redirection
   if (role === "u") {

--- a/src/handlers/handleWrite.js
+++ b/src/handlers/handleWrite.js
@@ -132,8 +132,8 @@ export async function handlePostOrPut(request, env, ctx, isPut) {
     if (item.value === null) {
       throw new WorkerError(404, `paste of name '${short}' is not found`)
     } else {
-      const date = item.metadata.postedAt
-      if (passwd !== item.metadata.passwd) {
+      const date = item.metadata?.postedAt
+      if (passwd !== item.metadata?.passwd) {
         throw new WorkerError(403, `incorrect password for paste '${short}`)
       } else {
         return makeResponse(


### PR DESCRIPTION
fix `Error 500: Cannot read properties of null` on old kv records

Maybe not every change is needed, but i think there's no harm in changing `item.metadata -> item.metadata?` uniformly?