### PR TITLE
fix: Ensure dist/frontend is created before build and clarify deploy workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You are free to deploy the pastebin on your own domain if you host your domain o
 ```console
 $ yarn install
 $ yarn wrangler login
+$ yarn build:frontend
 $ yarn deploy
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "scripts": {
     "deploy": "wrangler deploy",
-    "build:frontend": "vite build frontend --outDir ../dist/frontend --emptyOutDir",
+    "prebuild:frontend": "mkdir -p dist/frontend",
+    "build:frontend": "yarn prebuild:frontend && vite build frontend --outDir ../dist/frontend --emptyOutDir",
     "build:frontend:dev": "vite build frontend --mode development --outDir ../dist/frontend --emptyOutDir",
     "dev:frontend": "vite serve frontend --mode development",
     "dev": "wrangler dev --var DEPLOY_URL:http://localhost:8787 --port 8787",


### PR DESCRIPTION
### Summary

This PR improves the deployment workflow by ensuring the required `dist/frontend` directory is always created before building the frontend, and clarifies the necessary steps in the README.

- Adds a `prebuild:frontend` script to [package.json](cci:7://file:///Users/choco/Documents/Workspaces/pastebin-worker/package.json:0:0-0:0) that creates the `dist/frontend` directory if it does not exist.
- Updates the `build:frontend` script to run the prebuild step before building with Vite.
- Updates the README deploy instructions to explicitly include `yarn build:frontend` before deploying.

### Motivation

Without these changes, new users may encounter errors if the `dist/frontend` directory does not exist, or may miss the required frontend build step before deploying. This PR streamlines the setup and deployment process for all users.

### How to test

1. Clone the repo and follow the updated README deploy steps.
2. Confirm that `yarn build:frontend` works without manual directory creation.
3. Confirm that deployment proceeds smoothly.

---

Thank you for considering this improvement!