### PR TITLE
Default client encryption option

### DIFF
--- a/frontend/pages/PasteBin.tsx
+++ b/frontend/pages/PasteBin.tsx
@@ -38,7 +38,7 @@ export function PasteBin() {
     name: "",
     password: "",
     uploadKind: "short",
-    doEncrypt: false,
+    doEncrypt: DEFAULT_CLIENT_ENCRYPTION,
   })
 
   const [pasteResponse, setPasteResponse] = useState<PasteResponse | undefined>(undefined)

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -4,3 +4,4 @@ declare const REPO: string
 declare const MAX_EXPIRATION: string
 declare const DEFAULT_EXPIRATION: string
 declare const INDEX_PAGE_TITLE: string
+declare const DEFAULT_CLIENT_ENCRYPTION: boolean

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -42,6 +42,7 @@ export default defineConfig(({ mode }) => {
       MAX_EXPIRATION: JSON.stringify(getVar("MAX_EXPIRATION")),
       DEFAULT_EXPIRATION: JSON.stringify(getVar("DEFAULT_EXPIRATION")),
       INDEX_PAGE_TITLE: JSON.stringify(indexTitle),
+      DEFAULT_CLIENT_ENCRYPTION: getVar("DEFAULT_CLIENT_ENCRYPTION"),
     },
     server: {
       port: 5173,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,9 +13,11 @@ export default defineConfig(({ mode }) => {
   const wranglerConfigText = readFileSync(wranglerConfigPath, "utf8")
   const wranglerConfigParsed = toml.parse(wranglerConfigText)
 
-  function getVar(name) {
+  function getVar(name, defaultValue = undefined) {
     if (wranglerConfigParsed.vars !== undefined && wranglerConfigParsed.vars[name] !== undefined) {
       return wranglerConfigParsed.vars[name]
+    } else if (defaultValue !== undefined) {
+      return defaultValue
     } else {
       throw new Error(`Cannot find vars.${name} in ${wranglerConfigPath}`)
     }
@@ -42,7 +44,7 @@ export default defineConfig(({ mode }) => {
       MAX_EXPIRATION: JSON.stringify(getVar("MAX_EXPIRATION")),
       DEFAULT_EXPIRATION: JSON.stringify(getVar("DEFAULT_EXPIRATION")),
       INDEX_PAGE_TITLE: JSON.stringify(indexTitle),
-      DEFAULT_CLIENT_ENCRYPTION: getVar("DEFAULT_CLIENT_ENCRYPTION"),
+      DEFAULT_CLIENT_ENCRYPTION: getVar("DEFAULT_CLIENT_ENCRYPTION", false),
     },
     server: {
       port: 5173,

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -17,6 +17,7 @@ declare namespace Cloudflare {
 		R2_THRESHOLD: string;
 		R2_MAX_ALLOWED: string;
 		DISALLOWED_MIME_FOR_PASTE: string[];
+		DEFAULT_CLIENT_ENCRYPTION: boolean;
 		R2: R2Bucket;
 		ASSETS: Fetcher;
 	}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -75,3 +75,6 @@ R2_MAX_ALLOWED = "100M"
 
 # The following mimetypes will be converted to text/plain
 DISALLOWED_MIME_FOR_PASTE = ["text/html", "audio/x-mpegurl"]
+
+# Default client-side encryption setting (true/false)
+DEFAULT_CLIENT_ENCRYPTION = true


### PR DESCRIPTION
Adds an option to set a DEFAULT_CLIENT_ENCRYPTION in the wrangler.toml to have client encryption enabled by default.

Also adds the option to provide a defaultValue when calling getVar

>  function getVar(name, defaultValue = undefined) {