### PR TITLE
fix[worker]: make /api and /tos doc pages publicly accessible

### DIFF
--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -133,11 +133,6 @@ ${DARK_MODE_SCRIPT}
 
   const staticPageContent = getDocPage(url.pathname, env)
   if (staticPageContent) {
-    // access to all static pages requires auth
-    const authResponse = verifyAuth(request, env)
-    if (authResponse !== null) {
-      return authResponse
-    }
     return new Response(staticPageContent, {
       headers: {
         "Content-Type": "text/html;charset=UTF-8",

--- a/worker/test/basicAuth.spec.ts
+++ b/worker/test/basicAuth.spec.ts
@@ -79,6 +79,12 @@ describe("basic auth", () => {
     expect(await areBlobsEqual(await revisitUpdatedResp.blob(), blob2)).toStrictEqual(true)
   })
 
+  it("should allow accessing doc pages without auth", async () => {
+    for (const page of ["/api", "/tos"]) {
+      expect((await workerFetch(ctx, `${BASE_URL}${page}`)).status, `visiting ${page}`).toStrictEqual(200)
+    }
+  })
+
   it("should delete without auth", async () => {
     const uploadResp1 = await upload(ctx, { c: blob1 }, { headers: authHeader })
     const deleteResp = await workerFetch(


### PR DESCRIPTION
Doc pages (`/api`, `/tos`) are read-only references that shouldn't require
authentication. This removes the auth guard from those routes while keeping
all write endpoints and the upload UI protected.

Includes a test confirming both pages return 200 without credentials.