### PR TITLE
feat[worker]: add headless/API-only deployment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ $ pnpm deploy
 
 6. Enjoy!
 
+## Headless Mode
+
+For API-only deployments (no upload UI), set `HEADLESS_MODE = true` in `wrangler.toml`. The index page becomes a minimal landing page with usage instructions, and URL redirect (`/u/`) and article rendering (`/a/`) routes are disabled. All paste CRUD operations continue to work normally via the HTTP API. See [API reference](doc/api.md#headless-mode) for details.
+
 ## Auth
 
 If you want a private deployment (only you can upload paste, but everyone can read the paste), add the following entry to your `wrangler.toml`.

--- a/doc/api.md
+++ b/doc/api.md
@@ -304,3 +304,32 @@ the paste will be deleted in seconds
 $ curl https://shz.al/~hitagi
 not found
 ```
+
+## Headless Mode
+
+Set `HEADLESS_MODE = true` in `wrangler.toml` for an API-only deployment. This replaces the upload UI with a minimal landing page and disables non-essential routes:
+
+**Disabled routes:**
+
+- `GET /u/<name>` — URL redirect (returns 403)
+- `GET /a/<name>` — article/markdown rendering (returns 403)
+- `GET /<name>:<passwd>` — admin edit page (returns headless landing page instead)
+
+**Unaffected routes** (work identically with or without headless mode):
+
+- `POST /` — paste upload
+- `GET /<name>` — raw paste retrieval
+- `GET /d/<name>` — display page (needed for client-side decryption)
+- `GET /m/<name>` — paste metadata
+- `PUT /<name>:<passwd>` — paste update
+- `DELETE /<name>:<passwd>` — paste deletion
+- `HEAD /*` — metadata via headers
+- `/api`, `/tos` — documentation pages
+- `/favicon.ico`, `/assets/*` — static assets
+
+**Configuration:**
+
+```toml
+[vars]
+HEADLESS_MODE = true
+```

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -22,6 +22,7 @@ declare namespace Cloudflare {
 		R2_THRESHOLD: string;
 		R2_MAX_ALLOWED: string;
 		DISALLOWED_MIME_FOR_PASTE: string[];
+		HEADLESS_MODE: boolean;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -1,6 +1,7 @@
 import { decode, isLegalUrl, WorkerError, escapeHtml } from "../common.js"
 import { getDocPage } from "../pages/docs.js"
 import { verifyAuth } from "../pages/auth.js"
+import { headlessLandingPage } from "../pages/headless.js"
 import mime from "mime"
 import { makeMarkdown } from "../pages/markdown.js"
 import type { PasteMetadata, PasteWithMetadata } from "../storage/storage.js"
@@ -59,6 +60,15 @@ async function handleStaticPages(request: Request, env: Env, _: ExecutionContext
 
   // Handle index.html with SSR
   if (path === "/index.html") {
+    // Headless mode: return minimal landing page instead of React UI
+    if (env.HEADLESS_MODE) {
+      return new Response(headlessLandingPage(env), {
+        headers: {
+          "Content-Type": "text/html;charset=UTF-8",
+          ...staticPageCacheHeader(env),
+        },
+      })
+    }
     // Auth check
     const authResponse = verifyAuth(request, env)
     if (authResponse !== null) {
@@ -212,6 +222,9 @@ export async function handleGet(request: Request, env: Env, ctx: ExecutionContex
 
   // handle URL redirection
   if (role === "u") {
+    if (env.HEADLESS_MODE) {
+      throw new WorkerError(403, "URL redirect is disabled in headless mode")
+    }
     if (item.metadata.sizeBytes > MAX_URL_REDIRECT_LEN) {
       throw new WorkerError(400, `URL too long to be redirected (max ${MAX_URL_REDIRECT_LEN} bytes)`)
     }
@@ -225,6 +238,9 @@ export async function handleGet(request: Request, env: Env, ctx: ExecutionContex
 
   // handle article (render as markdown)
   if (role === "a") {
+    if (env.HEADLESS_MODE) {
+      throw new WorkerError(403, "Article rendering is disabled in headless mode")
+    }
     return new Response(shouldGetPasteContent ? makeMarkdown(await decodeMaybeStream(item.paste)) : null, {
       headers: {
         "Content-Type": `text/html;charset=UTF-8`,

--- a/worker/pages/headless.ts
+++ b/worker/pages/headless.ts
@@ -1,0 +1,17 @@
+export function headlessLandingPage(env: Env): string {
+  const title = env.INDEX_PAGE_TITLE || "Pastebin"
+  const deployUrl = env.DEPLOY_URL || ""
+  return `<!DOCTYPE html>
+<html><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+  <style>body{font-family:monospace;max-width:600px;margin:2em auto;padding:0 1em;line-height:1.6;}pre{background:#f4f4f4;padding:1em;overflow-x:auto;}</style>
+</head><body>
+  <h1>${title}</h1>
+  <p>API-only mode. Upload pastes via the HTTP API.</p>
+  <h2>Quick Start</h2>
+  <pre>curl -Fc=@file.txt ${deployUrl}</pre>
+  <p><a href="/api">API Reference</a> · <a href="/tos">Terms</a></p>
+</body></html>`
+}

--- a/worker/test/headlessMode.spec.ts
+++ b/worker/test/headlessMode.spec.ts
@@ -1,0 +1,72 @@
+import { expect, describe, it, beforeEach, afterEach } from "vitest"
+import { createExecutionContext, env } from "cloudflare:test"
+import { addRole, BASE_URL, genRandomBlob, upload, workerFetch } from "./testUtils"
+
+describe("headless mode", () => {
+  const ctx = createExecutionContext()
+  const blob1 = genRandomBlob(1024)
+
+  beforeEach(() => {
+    env.HEADLESS_MODE = true
+  })
+
+  afterEach(() => {
+    env.HEADLESS_MODE = false
+  })
+
+  it("should return headless landing page for GET /", async () => {
+    const resp = await workerFetch(ctx, BASE_URL)
+    expect(resp.status).toStrictEqual(200)
+    const text = await resp.text()
+    expect(text).toContain("API-only mode")
+    expect(text).toContain(env.DEPLOY_URL)
+    expect(resp.headers.get("Content-Type")).toStrictEqual("text/html;charset=UTF-8")
+  })
+
+  it("should return headless landing page for admin URL", async () => {
+    const uploadResp = await upload(ctx, { c: blob1 })
+    env.HEADLESS_MODE = true
+    const manageResp = await workerFetch(ctx, uploadResp.manageUrl)
+    expect(manageResp.status).toStrictEqual(200)
+    const text = await manageResp.text()
+    expect(text).toContain("API-only mode")
+  })
+
+  it("should still allow POST / to create pastes", async () => {
+    const resp = await upload(ctx, { c: blob1 })
+    expect(resp.url).toBeDefined()
+    expect(resp.manageUrl).toBeDefined()
+  })
+
+  it("should still allow GET /<name> to retrieve pastes", async () => {
+    const uploadResp = await upload(ctx, { c: blob1 })
+    const getResp = await workerFetch(ctx, uploadResp.url)
+    expect(getResp.status).toStrictEqual(200)
+  })
+
+  it("should still serve display page for GET /d/<name>", async () => {
+    const uploadResp = await upload(ctx, { c: blob1 })
+    const displayUrl = addRole(uploadResp.url, "d")
+    const displayResp = await workerFetch(ctx, displayUrl)
+    expect(displayResp.status).toStrictEqual(200)
+    expect(displayResp.headers.get("Content-Type")).toStrictEqual("text/html;charset=UTF-8")
+  })
+
+  it("should return 403 for GET /u/<name>", async () => {
+    const uploadResp = await upload(ctx, { c: new Blob(["https://example.com"]) })
+    const redirectUrl = addRole(uploadResp.url, "u")
+    const redirectResp = await workerFetch(ctx, redirectUrl)
+    expect(redirectResp.status).toStrictEqual(403)
+    const text = await redirectResp.text()
+    expect(text).toContain("URL redirect is disabled in headless mode")
+  })
+
+  it("should return 403 for GET /a/<name>", async () => {
+    const uploadResp = await upload(ctx, { c: new Blob(["# Hello"]) })
+    const articleUrl = addRole(uploadResp.url, "a")
+    const articleResp = await workerFetch(ctx, articleUrl)
+    expect(articleResp.status).toStrictEqual(403)
+    const text = await articleResp.text()
+    expect(text).toContain("Article rendering is disabled in headless mode")
+  })
+})

--- a/worker/test/headlessMode.spec.ts
+++ b/worker/test/headlessMode.spec.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it, beforeEach, afterEach } from "vitest"
 import { createExecutionContext, env } from "cloudflare:test"
-import { addRole, BASE_URL, genRandomBlob, upload, workerFetch } from "./testUtils"
+import { addRole, BASE_URL, genRandomBlob, upload, workerFetch } from "./testUtils.js"
 
 describe("headless mode", () => {
   const ctx = createExecutionContext()

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -75,3 +75,6 @@ R2_MAX_ALLOWED = "100M"
 
 # The following mimetypes will be converted to text/plain
 DISALLOWED_MIME_FOR_PASTE = ["text/html", "audio/x-mpegurl"]
+
+# Set to true for API-only mode: disables upload UI, URL redirects, and article rendering
+HEADLESS_MODE = false


### PR DESCRIPTION
Adds a `HEADLESS_MODE` environment variable for API-only deployments.

When enabled, the index route serves a minimal landing page with curl
usage instructions instead of the React frontend. URL redirect (`/u/`)
and article rendering (`/a/`) return 403, since they depend on the UI.
All read/write/delete API routes are unaffected.

Includes tests and documentation updates.