### PR TITLE
feat: improve keyboard navigation and accessibility for code editor

### DIFF
--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
+import type { SelectHandle } from "./ui/index.js"
 import { Autocomplete, AutocompleteItem, Input, Select, SelectItem } from "./ui/index.js"
 
 import { autoCompleteOverrides, inputOverrides, selectOverrides, tst } from "../utils/overrides.js"
 import { useHLJS, highlightHTML } from "../utils/HighlightLoader.js"
+import { XIcon } from "./icons.js"
 
 import "../styles/highlight-theme-light.css"
 import "../styles/highlight-theme-dark.css"
 
-// TODO:
-// - line number
-// - clear button
 interface CodeInputProps extends React.HTMLProps<HTMLDivElement> {
   content: string
   setContent: (code: string) => void
@@ -78,8 +77,10 @@ export function CodeEditor({
   const refHighlighting = useRef<HTMLPreElement | null>(null)
   const refTextarea = useRef<HTMLTextAreaElement | null>(null)
   const refLineNumbers = useRef<HTMLSpanElement | null>(null)
+  const refIndentWith = useRef<SelectHandle | null>(null)
 
   const lineCount = (content?.match(/\n/g)?.length || 0) + 1
+  const lineNumbers = useMemo(() => Array.from({ length: lineCount }, (_, idx) => <span key={idx} />), [lineCount])
   const [heightPx, setHeightPx] = useState<number>(Math.max(lineCount * 24, 100)) // Estimate initial height for SSR
   const hljs = useHLJS()
   const [tabSetting, setTabSettings] = useState<TabSetting>({ char: "space", width: 2 })
@@ -100,7 +101,10 @@ export function CodeEditor({
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
     const element = refTextarea.current!
-    if (event.key === "Tab") {
+    if (event.key === "Tab" && event.shiftKey) {
+      event.preventDefault()
+      refIndentWith.current?.focus()
+    } else if (event.key === "Tab") {
       event.preventDefault() // stop normal
       const beforeTab = content.slice(0, element.selectionStart)
       const afterTab = content.slice(element.selectionEnd, element.value.length)
@@ -142,9 +146,11 @@ export function CodeEditor({
           classNames={inputOverrides}
           type={"text"}
           label={"File name"}
+          placeholder={"No filename"}
           size={"sm"}
           value={filename || ""}
           onValueChange={setFilename}
+          isClearable
         />
         <Autocomplete
           className={"max-w-[8em]"}
@@ -165,6 +171,7 @@ export function CodeEditor({
           )}
         </Autocomplete>
         <Select
+          ref={refIndentWith}
           size={"sm"}
           label={"Indent With"}
           className={"w-[6em] text-foreground"}
@@ -181,7 +188,9 @@ export function CodeEditor({
           ))}
         </Select>
       </div>
-      <div className={`w-full bg-default-100 ${tst} rounded-xl p-2 relative`}>
+      <div
+        className={`text-sm w-full bg-default-100 ${tst} rounded-xl p-2 relative border border-default-200 hover:border-default-400 focus-within:border-default-400`}
+      >
         <div
           className={`relative w-full`}
           style={{ tabSize: tabSetting.char === "tab" ? tabSetting.width : undefined }}
@@ -201,13 +210,7 @@ export function CodeEditor({
               }
               style={{ height: `${heightPx}px` }}
             >
-              {useMemo(
-                () =>
-                  Array.from({ length: lineCount }, (_, idx) => {
-                    return <span key={idx} />
-                  }),
-                [lineCount],
-              )}
+              {lineNumbers}
             </span>
           </div>
           <textarea
@@ -226,6 +229,17 @@ export function CodeEditor({
             aria-label={"Paste editor"}
           ></textarea>
         </div>
+        {content && !disabled && (
+          <button
+            type="button"
+            onClick={() => setContent("")}
+            tabIndex={-1}
+            className="absolute top-3 right-3 text-default-400 hover:text-default-700 transition-colors"
+            aria-label="Clear editor"
+          >
+            <XIcon className="w-4 h-4" />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/frontend/components/PasteSettingPanel.tsx
+++ b/frontend/components/PasteSettingPanel.tsx
@@ -62,6 +62,7 @@ export function PanelSettingsPanel({ setting, onSettingChange, config, ...rest }
             label="Password"
             value={setting.password}
             onValueChange={(p) => onSettingChange({ ...setting, password: p })}
+            isClearable
             classNames={{
               base: "flex-1",
               ...inputOverrides,

--- a/frontend/components/ui/Autocomplete.tsx
+++ b/frontend/components/ui/Autocomplete.tsx
@@ -43,35 +43,49 @@ export function Autocomplete({
   readOnly,
 }: AutocompleteProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [internalValue, setInternalValue] = useState(selectedKey || inputValue)
-  const [focusedIndex, setFocusedIndex] = useState(-1)
+  const [internalValue, setInternalValue] = useState(selectedKey != null ? selectedKey : inputValue)
+  const [focusedKey, setFocusedKey] = useState<string | null>(null)
   const ref = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    setInternalValue(selectedKey || inputValue)
+    if (focusedKey === null || !listRef.current) return
+    const el = listRef.current.querySelector<HTMLElement>(`[data-key="${CSS.escape(focusedKey)}"]`)
+    el?.scrollIntoView({ block: "nearest" })
+  }, [focusedKey])
+
+  useEffect(() => {
+    setInternalValue(selectedKey != null ? selectedKey : inputValue)
   }, [selectedKey, inputValue])
 
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false)
-      }
-    }
-    document.addEventListener("mousedown", handleClick)
-    return () => document.removeEventListener("mousedown", handleClick)
-  }, [])
+  const filterItems = (items: { key: string }[], value: string) => {
+    const lower = value.toLowerCase()
+    return items.filter((item) =>
+      lower.length <= 2 ? item.key.toLowerCase().startsWith(lower) : item.key.toLowerCase().includes(lower),
+    )
+  }
 
-  const filtered = defaultItems.filter((item) => item.key.toLowerCase().includes(internalValue.toLowerCase()))
+  const filtered = filterItems(defaultItems, internalValue)
+
+  const defaultFocusKey = (list: { key: string }[]) => {
+    if (list.length === 0) return null
+    const inList = selectedKey && list.some((item) => item.key === selectedKey)
+    return inList ? selectedKey : list[0].key
+  }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!isOpen) return
 
+    const focusedIndex = focusedKey !== null ? filtered.findIndex((item) => item.key === focusedKey) : -1
+
     if (e.key === "ArrowDown") {
       e.preventDefault()
-      setFocusedIndex((prev) => (prev < filtered.length - 1 ? prev + 1 : prev))
+      const next = focusedIndex < filtered.length - 1 ? focusedIndex + 1 : focusedIndex
+      if (next >= 0) setFocusedKey(filtered[next].key)
     } else if (e.key === "ArrowUp") {
       e.preventDefault()
-      setFocusedIndex((prev) => (prev > 0 ? prev - 1 : 0))
+      const prev = focusedIndex > 0 ? focusedIndex - 1 : 0
+      if (prev >= 0) setFocusedKey(filtered[prev].key)
     } else if (e.key === "Enter" && focusedIndex >= 0) {
       e.preventDefault()
       const item = filtered[focusedIndex]
@@ -79,10 +93,10 @@ export function Autocomplete({
       setInternalValue(item.key)
       onInputChange?.(item.key)
       setIsOpen(false)
-      setFocusedIndex(-1)
+      setFocusedKey(null)
     } else if (e.key === "Escape") {
       setIsOpen(false)
-      setFocusedIndex(-1)
+      setFocusedKey(null)
     }
   }
 
@@ -99,32 +113,47 @@ export function Autocomplete({
           setInternalValue(val)
           onInputChange?.(val)
           setIsOpen(true)
-          setFocusedIndex(-1)
+          const newFiltered = filterItems(defaultItems, val)
+          setFocusedKey((prev) => {
+            if (prev !== null && newFiltered.some((item) => item.key === prev)) return prev
+            return defaultFocusKey(newFiltered)
+          })
         }}
         onKeyDown={handleKeyDown}
-        onFocus={() => setIsOpen(true)}
-        className={`w-full px-3 py-2 bg-default-100 border border-default-200 rounded-xl text-sm text-foreground hover:border-default-300 focus:border-default-400 focus:outline-none transition-colors ${classNames.input || ""}`}
+        onFocus={() => {
+          setIsOpen(true)
+          setFocusedKey(defaultFocusKey(filtered))
+        }}
+        onBlur={(e) => {
+          if (!ref.current?.contains(e.relatedTarget as Node)) {
+            setIsOpen(false)
+            setFocusedKey(null)
+          }
+        }}
+        className={`w-full px-3 py-2 bg-default-100 rounded-xl text-sm text-foreground border focus:outline-none transition-colors ${isOpen ? "border-default-400" : "border-default-200 hover:border-default-400"} ${classNames.input || ""}`}
       />
       {isOpen && filtered.length > 0 && (
         <div
           className={`absolute z-10 w-full mt-1 bg-content1 border border-default-200 rounded-lg overflow-hidden shadow-medium ${classNames.listbox || ""}`}
         >
-          <div className="overflow-auto max-h-60">
-            {filtered.map((item, index) => {
+          <div ref={listRef} tabIndex={-1} className="overflow-auto max-h-60">
+            {filtered.map((item) => {
               const element = children(item)
               return (
                 <button
                   key={item.key}
+                  data-key={item.key}
                   type="button"
                   tabIndex={-1}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     onSelectionChange?.(item.key)
                     setInternalValue(item.key)
                     onInputChange?.(item.key)
                     setIsOpen(false)
-                    setFocusedIndex(-1)
+                    setFocusedKey(null)
                   }}
-                  className={`w-full px-3 py-2 text-left text-sm transition-colors ${index === focusedIndex ? "bg-default-100" : "hover:bg-default-100"}`}
+                  className={`w-full px-3 py-2 text-left text-sm transition-colors ${item.key === focusedKey ? "bg-default-100" : "hover:bg-default-100"}`}
                 >
                   {element.props.children as React.ReactNode}
                 </button>

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { XIcon } from "../icons.js"
 
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
   label?: string
@@ -7,10 +8,12 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
   errorMessage?: string
   isInvalid?: boolean
   isRequired?: boolean
+  isClearable?: boolean
   color?: "default" | "success"
   startContent?: React.ReactNode
   endContent?: React.ReactNode
   onValueChange?: (value: string) => void
+  onClear?: () => void
   classNames?: {
     base?: string
     label?: string
@@ -27,14 +30,17 @@ export function Input({
   errorMessage,
   isInvalid,
   isRequired,
+  isClearable,
   color = "default",
   startContent,
   endContent,
   onValueChange,
+  onClear,
   className = "",
   classNames = {},
   onChange,
   defaultValue: _defaultValue,
+  value,
   ...rest
 }: InputProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -42,14 +48,21 @@ export function Input({
     onValueChange?.(e.target.value)
   }
 
+  const handleClear = () => {
+    onValueChange?.("")
+    onClear?.()
+  }
+
+  const showClearButton = isClearable && value !== undefined && value !== ""
+
   const borderColor = isInvalid
-    ? "border-danger focus:border-danger"
+    ? "border-danger focus-within:border-danger"
     : color === "success"
-      ? "border-success focus:border-success"
-      : "border-default-200 focus:border-default-400 hover:border-default-300"
+      ? "border-success focus-within:border-success"
+      : "border-default-200 focus-within:border-default-400 hover:border-default-300"
 
   return (
-    <div className={`flex flex-col gap-1.5 ${classNames.base || className}`}>
+    <div className={`flex flex-col gap-1.5 ${className} ${classNames.base || ""}`}>
       {label && (
         <label className={`pl-1 text-sm text-default-500 ${classNames.label || ""}`}>
           {label}
@@ -57,16 +70,29 @@ export function Input({
         </label>
       )}
       <div
-        className={`flex items-center bg-default-100 border rounded-xl ${borderColor} ${startContent || endContent ? "px-3" : ""}`}
+        className={`flex items-center bg-default-100 border rounded-xl color-tst ${borderColor} ${startContent || endContent || showClearButton ? "px-3" : ""}`}
       >
         {startContent && <div className="flex-shrink-0">{startContent}</div>}
         <input
           aria-label={label}
           aria-invalid={isInvalid}
-          className={`flex-1 py-2 bg-transparent text-sm text-foreground focus:outline-none ${startContent || endContent ? "" : "px-3"} ${classNames.input || ""}`}
+          className={`flex-1 py-2 bg-transparent text-sm text-foreground focus:outline-none color-tst ${startContent || endContent || showClearButton ? "" : "px-3"} ${classNames.input || ""}`}
           onChange={handleChange}
+          value={value}
           {...rest}
         />
+        {showClearButton && (
+          <button
+            type="button"
+            tabIndex={-1}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleClear}
+            className="flex-shrink-0 text-default-400 hover:text-default-700 color-tst focus:outline-none"
+            aria-label="Clear input"
+          >
+            <XIcon className="w-4 h-4" />
+          </button>
+        )}
         {endContent && <div className="flex-shrink-0">{endContent}</div>}
       </div>
       {(description || errorMessage) && (

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react"
+import React, { useState, useRef, useEffect, useImperativeHandle } from "react"
 
 export interface SelectItemProps {
   children: React.ReactNode
@@ -7,6 +7,10 @@ export interface SelectItemProps {
 
 export function SelectItem({ children }: SelectItemProps) {
   return <>{children}</>
+}
+
+export interface SelectHandle {
+  focus(): void
 }
 
 export interface SelectProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onChange"> {
@@ -22,39 +26,40 @@ export interface SelectProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
   children: React.ReactNode
 }
 
-export function Select({
-  label,
-  size: _size = "md",
-  selectedKeys = [],
-  onSelectionChange,
-  className,
-  classNames = {},
-  children,
-  ...rest
-}: SelectProps) {
+export const Select = React.forwardRef<SelectHandle, SelectProps>(function Select(
+  { label, size: _size = "md", selectedKeys = [], onSelectionChange, className, classNames = {}, children, ...rest },
+  forwardedRef,
+) {
   const [isOpen, setIsOpen] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(-1)
-  const ref = useRef<HTMLDivElement>(null)
+  const innerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const focusFromMouseRef = useRef(false)
+
+  useImperativeHandle(forwardedRef, () => ({
+    focus() {
+      triggerRef.current?.focus()
+    },
+  }))
 
   useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false)
-        setFocusedIndex(-1)
-      }
-    }
-    document.addEventListener("mousedown", handleClick)
-    return () => document.removeEventListener("mousedown", handleClick)
-  }, [])
+    if (focusedIndex < 0 || !listRef.current) return
+    const el = listRef.current.querySelector<HTMLElement>(`[data-index="${focusedIndex}"]`)
+    el?.scrollIntoView({ block: "nearest" })
+  }, [focusedIndex])
 
   const items = React.Children.toArray(children).filter((child): child is React.ReactElement<SelectItemProps> =>
     React.isValidElement(child),
   )
 
-  const selected = items.find((item) => {
-    const itemValue = item.props.value ?? String(item.key).replace(/^\.\$/, "")
-    return selectedKeys.includes(itemValue)
-  })
+  const getItemValue = (item: React.ReactElement<SelectItemProps>) =>
+    item.props.value ?? String(item.key).replace(/^\.\$/, "")
+
+  const selectedIndex = items.findIndex((item) => selectedKeys.includes(getItemValue(item)))
+  const openFocusIndex = selectedIndex >= 0 ? selectedIndex : 0
+
+  const selected = items[selectedIndex]
   const displayText = selected?.props.children || label || "Select..."
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -62,7 +67,7 @@ export function Select({
       if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
         e.preventDefault()
         setIsOpen(true)
-        setFocusedIndex(0)
+        setFocusedIndex(openFocusIndex)
       }
       return
     }
@@ -75,9 +80,7 @@ export function Select({
       setFocusedIndex((prev) => (prev > 0 ? prev - 1 : 0))
     } else if (e.key === "Enter" && focusedIndex >= 0) {
       e.preventDefault()
-      const item = items[focusedIndex]
-      const itemValue = item.props.value ?? String(item.key).replace(/^\.\$/, "")
-      onSelectionChange?.(new Set([itemValue]))
+      onSelectionChange?.(new Set([getItemValue(items[focusedIndex])]))
       setIsOpen(false)
       setFocusedIndex(-1)
     } else if (e.key === "Escape") {
@@ -87,13 +90,30 @@ export function Select({
   }
 
   return (
-    <div ref={ref} className={`relative ${classNames.base || ""} ${className || ""}`} {...rest}>
+    <div ref={innerRef} className={`relative ${classNames.base || ""} ${className || ""}`} {...rest}>
       {label && <label className="pl-1 text-sm text-default-500 block mb-1.5">{label}</label>}
       <button
+        ref={triggerRef}
         type="button"
+        onMouseDown={() => {
+          focusFromMouseRef.current = true
+        }}
+        onFocus={() => {
+          if (!focusFromMouseRef.current) {
+            setIsOpen(true)
+            setFocusedIndex(openFocusIndex)
+          }
+          focusFromMouseRef.current = false
+        }}
+        onBlur={(e) => {
+          if (!innerRef.current?.contains(e.relatedTarget as Node)) {
+            setIsOpen(false)
+            setFocusedIndex(-1)
+          }
+        }}
         onClick={() => setIsOpen(!isOpen)}
         onKeyDown={handleKeyDown}
-        className={`w-full px-3 py-2 bg-default-100 border border-default-200 rounded-xl text-left text-sm hover:border-default-300 transition-colors ${classNames.trigger || ""}`}
+        className={`w-full px-3 py-2 bg-default-100 border rounded-xl text-left text-sm transition-colors focus:outline-none ${isOpen ? "border-default-400" : "border-default-200 hover:border-default-400"} ${classNames.trigger || ""}`}
       >
         {displayText}
       </button>
@@ -101,14 +121,16 @@ export function Select({
         <div
           className={`absolute z-10 left-0 right-0 mt-1 bg-content1 border border-default-200 rounded-lg max-h-60 overflow-hidden shadow-medium ${classNames.listbox || ""}`}
         >
-          <div className="overflow-auto max-h-60">
+          <div ref={listRef} tabIndex={-1} className="overflow-auto max-h-60">
             {items.map((item, index) => {
-              const itemValue = item.props.value ?? String(item.key).replace(/^\.\$/, "")
+              const itemValue = getItemValue(item)
               return (
                 <button
                   key={itemValue}
+                  data-index={index}
                   type="button"
                   tabIndex={-1}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     onSelectionChange?.(new Set([itemValue]))
                     setIsOpen(false)
@@ -125,4 +147,4 @@ export function Select({
       )}
     </div>
   )
-}
+})

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -32,7 +32,7 @@ export { Tabs, Tab } from "./Tabs.js"
 export type { TabsProps, TabProps } from "./Tabs.js"
 
 export { Select, SelectItem } from "./Select.js"
-export type { SelectProps, SelectItemProps } from "./Select.js"
+export type { SelectProps, SelectItemProps, SelectHandle } from "./Select.js"
 
 export { Autocomplete, AutocompleteItem } from "./Autocomplete.js"
 export type { AutocompleteProps, AutocompleteItemProps } from "./Autocomplete.js"


### PR DESCRIPTION
- Open Autocomplete/Select dropdown on focus; close on blur
- Autocomplete defaults focus to selected item when opening; maintains
  focus across filter changes; prefix match for <=2 chars input
- Shift+Tab in editor jumps back to Indent With selector
- Clear buttons (editor and input fields) excluded from tab order
- File name input shows "No filename" placeholder

fix: various UI bugs

- Autocomplete/Select/Input: prevent blur/click race condition on list
  item click with onMouseDown preventDefault
- Select: keyboard navigation now scrolls list into view
- Select: keyboard open focuses currently selected item instead of first
- Input: focus border now uses focus-within for correct browser behavior
- Input: fix dark mode color transition flickering with color-tst
- Input: classNames.base no longer silently drops className prop

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
