### PR TITLE
fix[worker]: remove compromised polyfill.io script

### DIFF
--- a/worker/pages/markdown.ts
+++ b/worker/pages/markdown.ts
@@ -59,7 +59,6 @@ export function makeMarkdown(content: string): string {
   <link href='https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism.css' rel='stylesheet' />
   <link href='https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/line-numbers/prism-line-numbers.css' rel='stylesheet' />
   <link rel='stylesheet' href='https://pages.github.com/assets/css/style.css'>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script id="MathJax-script" async
           src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
   </script>


### PR DESCRIPTION
## Summary

- Remove the `polyfill.io` script tag from the markdown renderer (`worker/pages/markdown.ts`)
- The `polyfill.io` domain was [acquired by a malicious entity](https://sansec.io/research/polyfill-supply-chain-attack) and now serves injected code to visitors
- The polyfill was only needed for ES6 support for MathJax, but MathJax v3 (already in use) handles its own polyfilling and all modern browsers support ES6 natively

## Test plan

- [ ] Verify markdown rendering with MathJax formulas still works (e.g. upload a paste with `$$E=mc^2$$` and view with `/a/` role)
- [ ] Verify Prism syntax highlighting in markdown pastes still works
- [ ] Existing tests pass (`pnpm test`)