### PR TITLE
fix[worker]: use constant-time comparison for password verification

### DIFF
--- a/worker/common.ts
+++ b/worker/common.ts
@@ -50,3 +50,12 @@ export function genRandStr(len: number) {
 export function isLegalUrl(url: string): boolean {
   return URL.canParse(url)
 }
+
+export function timingSafeEqual(a: string | undefined | null, b: string): boolean {
+  if (a === undefined || a === null) return false
+  const encoder = new TextEncoder()
+  const bufA = encoder.encode(a)
+  const bufB = encoder.encode(b)
+  if (bufA.byteLength !== bufB.byteLength) return false
+  return crypto.subtle.timingSafeEqual(bufA, bufB)
+}

--- a/worker/handlers/handleDelete.ts
+++ b/worker/handlers/handleDelete.ts
@@ -1,4 +1,4 @@
-import { WorkerError } from "../common.js"
+import { WorkerError, timingSafeEqual } from "../common.js"
 import { deletePaste, getPasteMetadata } from "../storage/storage.js"
 import { parsePath } from "../../shared/parsers.js"
 
@@ -9,7 +9,7 @@ export async function handleDelete(request: Request, env: Env, _: ExecutionConte
   if (metadata === null) {
     throw new WorkerError(404, `paste of name '${name}' not found`)
   } else {
-    if (password !== metadata.passwd) {
+    if (!timingSafeEqual(password, metadata.passwd)) {
       throw new WorkerError(403, `incorrect password for paste '${name}`)
     } else {
       await deletePaste(env, name, metadata)

--- a/worker/handlers/handleMPU.ts
+++ b/worker/handlers/handleMPU.ts
@@ -1,6 +1,6 @@
 import type { MPUCreateResponse } from "../../shared/interfaces.js"
 import { NAME_REGEX, PASTE_NAME_LEN, PRIVATE_PASTE_NAME_LEN } from "../../shared/constants.js"
-import { genRandStr, WorkerError } from "../common.js"
+import { genRandStr, WorkerError, timingSafeEqual } from "../common.js"
 import { getPasteMetadata, pasteNameAvailable } from "../storage/storage.js"
 import { parseSize } from "../../shared/parsers.js"
 
@@ -47,7 +47,7 @@ export async function handleMPUCreateUpdate(request: Request, env: Env): Promise
   if (metadata === null) {
     throw new WorkerError(404, `paste of name ‘${name}’ is not found`)
   }
-  if (password !== metadata.passwd) {
+  if (!timingSafeEqual(password, metadata.passwd)) {
     throw new WorkerError(403, `incorrect password for paste ‘${name}’`)
   }
 

--- a/worker/handlers/handleWrite.ts
+++ b/worker/handlers/handleWrite.ts
@@ -1,5 +1,5 @@
 import { verifyAuth } from "../pages/auth.js"
-import { decode, genRandStr, WorkerError } from "../common.js"
+import { decode, genRandStr, WorkerError, timingSafeEqual } from "../common.js"
 import { createPaste, getPasteMetadata, pasteNameAvailable, updatePaste } from "../storage/storage.js"
 import {
   DEFAULT_PASSWD_LEN,
@@ -182,7 +182,7 @@ export async function handlePostOrPut(
     }
 
     // no need to check password for MPCComplete, it is already checked on creation
-    if (!isMPUComplete && password !== originalMetadata.passwd) {
+    if (!isMPUComplete && !timingSafeEqual(password, originalMetadata.passwd)) {
       throw new WorkerError(403, `incorrect password for paste ‘${pasteName}’`)
     }
 


### PR DESCRIPTION
## Summary

- Add `timingSafeEqual()` helper to `worker/common.ts` using `crypto.subtle.timingSafeEqual`
- Replace `!==` string comparisons with the new helper in all three password check locations:
  - `worker/handlers/handleDelete.ts` — paste deletion
  - `worker/handlers/handleMPU.ts` — multipart upload update
  - `worker/handlers/handleWrite.ts` — paste update
- Prevents timing side-channel attacks that could leak password characters through response time differences
- Behavior is identical — only the comparison method changes

## Test plan

- [ ] All existing password-related tests pass unchanged (`basic.spec.ts`, `uploadOptions.spec.ts`, `mpu.spec.ts`)
- [ ] Correct password still grants access (update/delete)
- [ ] Wrong password still returns 403
- [ ] Missing password still returns 403
- [ ] `pnpm test` passes