### PR TITLE
feat: add CLI usage docs and serve plain markdown to curl UA

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This is a pastebin that can be deployed on Cloudflare workers. Try it on [shz.al
 
 3. [pb](/scripts) is a bash script to make it easier to use on command line.
 
+4. [SKILL.md](SKILL.md) is a concise, AI-agent-oriented packaging of the API. Make it available to your coding agent so it can upload, fetch, and manage pastes via this service.
+
 ## Limitations
 
 1. If deployed on Cloudflare Worker free-tier plan, the service allows at most 100,000 reads and 1000 writes, 1000 deletes per day.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: shz-al
+description: Upload, fetch, update, or delete text/binary content via shz.al, a curl-friendly pastebin. Use when you need a quick public URL for sharing long output, hosting a small file, shortening a URL, or rendering markdown as HTML.
+---
+
+# shz.al
+
+A pastebin hosted on Cloudflare Workers at `https://shz.al`. Every operation is
+plain HTTP and works with `curl`. Random paste names appear bare (e.g. `abcd`);
+custom names are returned with a leading `~` (e.g. `~hitagi`).
+
+## Upload
+
+```shell
+curl -Fc='hello, world' https://shz.al        # text
+curl -Fc=@file.png      https://shz.al        # file
+<cmd> | curl -Fc=@-     https://shz.al        # stdin
+```
+
+Response:
+
+```json
+{
+  "url": "https://shz.al/abcd",
+  "manageUrl": "https://shz.al/abcd:<password>",
+  "expireAt": "2026-05-21T10:33:06.114Z"
+}
+```
+
+Persist `manageUrl` if the paste may need to be updated or deleted later — it
+is the only way to authenticate as the owner.
+
+## Optional upload fields
+
+- `-Fn=<name>` — custom name (≥3 chars, returned prefixed with `~`).
+- `-Fe=<expire>` — expiration: integer/float with unit `s`/`m`/`h`/`d`
+  (default seconds). E.g. `-Fe=30m`, `-Fe=14d`.
+- `-Fs=<password>` — set a specific management password.
+- `-Flang=<lang>` — mark for syntax highlighting on the display page.
+- `-Fp=1` — private mode: 24-char unguessable random name.
+
+## Fetch
+
+```shell
+curl https://shz.al/<name>                    # raw content
+curl -OJ https://shz.al/~<name>               # save with server filename
+curl https://shz.al/m/<name>                  # JSON metadata (size, dates, …)
+curl -I https://shz.al/<name>                 # HEAD only
+```
+
+Append `?a` for `Content-Disposition: attachment`, `?mime=<mime>` to override
+the response Content-Type, or append `.<ext>` to the path to set Content-Type
+by extension.
+
+## Update / delete
+
+```shell
+curl -X PUT    -Fc='new content' <manageUrl>
+curl -X DELETE                   <manageUrl>
+```
+
+`PUT` accepts the same fields as upload; `e` recalculates expiration from now.
+
+## Other URL forms
+
+- `/d/<name>` — display page with syntax highlighting.
+- `/a/<name>` — render the paste as HTML (GitHub-flavored Markdown + MathJax).
+- `/u/<name>` — redirect to the URL stored in the paste (URL shortener).
+
+## Full docs
+
+- `https://shz.al/doc/curl.md` — comprehensive curl guide.
+- `https://shz.al/doc/api.md` — HTTP API reference.

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,4 +1,4 @@
-# API Reference
+# HTTP API Reference
 
 ## GET `/`
 
@@ -14,7 +14,7 @@ The `Content-Disposition` header is set to `inline` by default. But can be overr
 
 If the paste is encrypted, an `X-PB-Encryption-Scheme` header will be set to the encryption scheme.
 
-If the paste is uploaded with a `lang` parameter, an `X-PB-Highlight-Language` header will be set to the encryption scheme.
+If the paste is uploaded with a `lang` parameter, an `X-PB-Highlight-Language` header will be set to the highlight language.
 
 - `?a=`: optional. Set `Content-Disposition` to `attachment` if present.
 
@@ -26,21 +26,6 @@ If error occurs, the worker returns status code different from `200`:
 
 - `404`: the paste of given name is not found.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
-
-Usage example:
-
-```shell
-$ curl https://shz.al/i-p-
-https://web.archive.org/web/20210328091143/https://mp.weixin.qq.com/s/5phCQP7i-JpSvzPEMGk56Q
-
-$ curl https://shz.al/~panty.jpg | feh -
-
-$ curl 'https://shz.al/~panty.jpg?mime=image/png' -w '%{content_type}' -o /dev/null -sS
-image/png
-
-$ curl 'https://shz.al/kf7Z/panty.jpg?mime=image/png' -w '%{content_type}' -o /dev/null -sS
-image/png
-```
 
 ## GET `/<name>:<passwd>`
 
@@ -60,28 +45,14 @@ If error occurs, the worker returns status code different from `302`:
 - `404`: the paste of given name is not found.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
 
-Usage example:
-
-```shell
-$ firefox https://shz.al/u/i-p-
-
-$ curl -L https://shz.al/u/i-p-
-```
-
-## GET `/d/<name>`
+## **GET** `/d/<name>[.<ext>]` or `/d/<name>/<filename>`
 
 Return the web page that will display the content of the paste of name `<name>`. If the paste is encrypted, a key can be appended to the URL to decrypt the paste of name `<name>` in browser.
 
-If error occurs, the worker returns status code different from `302`:
+If error occurs, the worker returns status code different from `200`:
 
 - `404`: the paste of given name is not found.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
-
-Usage example:
-
-```shell
-$ firefox https://shz.al/d/i-p-
-```
 
 ## GET `/m/<name>`
 
@@ -92,10 +63,9 @@ If error occurs, the worker returns status code different from `200`:
 - `404`: the paste of given name is not found.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
 
-Usage example:
+The response body is a JSON object, for example:
 
-```shell
-$ curl -L https://shz.al/m/i-p-
+```json
 {
   "lastModifiedAt": "2025-05-05T10:33:06.114Z",
   "createdAt": "2025-05-01T10:33:06.114Z",
@@ -103,25 +73,27 @@ $ curl -L https://shz.al/m/i-p-
   "sizeBytes": 4096,
   "location": "KV",
   "filename": "a.jpg",
+  "highlightLanguage": "rust",
   "encryptionScheme": "AES-GCM"
 }
 ```
 
 Explanation of the fields:
 
-- `lastModified`: String. An ISO String representing the last modification time of the paste.
+- `lastModifiedAt`: String. An ISO String representing the last modification time of the paste.
 - `expireAt`: String. An ISO String representing when the paste will expire.
-- `expireAt`: String. An ISO String representing when the paste was created.
+- `createdAt`: String. An ISO String representing when the paste was created.
 - `sizeBytes`: Integer. The size of the content of the paste in bytes.
 - `filename`: Optional string. The file name of the paste.
-- `location`: String, either "KV" of "R2". Representing whether the paste content is stored in Cloudflare KV storage or R2 object storage.
-- `encryptionScheme`: Optional string. Currently only "AES-GCM" is possible. The encryption scheme used to encrypt the pastused to encrypt the pastused to encrypt the pastused to encrypt the paste.
+- `location`: String, either "KV" or "R2". Representing whether the paste content is stored in Cloudflare KV storage or R2 object storage.
+- `highlightLanguage`: Optional string. The syntax highlighting language uploaded with the `lang` form field.
+- `encryptionScheme`: Optional string. Currently only "AES-GCM" is possible. The encryption scheme used to encrypt the paste.
 
 ## GET `/a/<name>`
 
 Return the HTML converted from the markdown file stored in the paste of name `<name>`. The markdown conversion follows GitHub Flavored Markdown (GFM) Spec, supported by [remark-gfm](https://github.com/remarkjs/remark-gfm).
 
-Syntax highlighting is supported by [prims.js](https://prismjs.com/). LaTeX mathematics is supported by [MathJax](https://www.mathjax.org).
+Syntax highlighting is supported by [prism.js](https://prismjs.com/). LaTeX mathematics is supported by [MathJax](https://www.mathjax.org).
 
 If error occurs, the worker returns status code different from `200`:
 
@@ -164,30 +136,24 @@ $$
 $$
 ```
 
-```shell
-$ curl -Fc=@test.md -Fn=test-md https://shz.al
-
-$ firefox https://shz.al/a/~test-md
-```
-
 ## **HEAD** `/*`
 
-Request a paste without returning the body. It accepts same parameters as all `GET` requests, and returns the same `Content-Type`, `Content-Disposition`, `Content-Length` and cache control headers with the corresponding `GET` request. Note that the `Content-Length` with `/a/<name>`, `?lang=<lang>` is the length of the paste instead of the length the actuala HTML page.
+Request a paste without returning the body. It accepts same parameters as all `GET` requests, and returns the same `Content-Type`, `Content-Disposition`, `Content-Length` and cache control headers with the corresponding `GET` request. Note that the `Content-Length` with `/a/<name>`, `?lang=<lang>` is the length of the paste instead of the length of the actual HTML page.
 
 ## **POST** `/`
 
 Upload your paste. It accept parameters in form-data:
 
-- `c`: mandatory. The **content** of your paste, text of binary. It should be no larger than 10 MB. The `filename` in its `Content-Disposition` will be present when fetching the paste.
+- `c`: mandatory. The **content** of your paste, text or binary. The maximum allowed size is set by the deployment (`R2_MAX_ALLOWED`). The `filename` in its `Content-Disposition` will be present when fetching the paste.
 
-- `e`: optional. The **expiration** time of the paste. After this period of time, the paste is permanently deleted. It should be an integer or a float point number suffixed with an optional unit (seconds by default). Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). For example, `360.24` means 360.25 seconds; `25d` is interpreted as 25 days. The actual expiration might be shorter than specified expiration due to limitations imposed by the administrator. If unspecified, a default expiration time setting is used.
+- `e`: optional. The **expiration** time of the paste. After this period of time, the paste is permanently deleted. It should be an integer or a float point number suffixed with an optional unit (seconds by default). Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). For example, `360.25` means 360.25 seconds, and `25d` means 25 days. The actual expiration might be shorter than specified expiration due to limitations imposed by the administrator. If unspecified, a default expiration time setting is used.
 
 - `s`: optional. The **password** which allows you to modify and delete the paste. If not specified, the worker will generate a random string as password.
 
 - `n`: optional. The customized **name** of your paste. If not specified, the worker will generate a random string (4 characters by default) as the name. You need to prefix the name with `~` when fetching the paste of customized name. The name is at least 3 characters long, consisting of alphabet, digits and characters in `+_-[]*$=@,;/`.
 
 - `p`: optional. The flag of **private mode**. If specified to any value, the name of the paste is as long as 24 characters. No effect if `n` is used.
--
+
 - `encryption-scheme`: optional. The encryption scheme used in the uploaded paste. It will be returned as `X-PB-Encryption-Scheme` header on fetching paste. Note that this is not the encryption scheme that the backend will perform.
 
 - `lang`: optional. The language of the uploaded paste for syntax highlighting. Should be a lower-case name of language listed in [highlight.js documentation](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md). This will be returned as `X-PB-Highlight-Language` header on fetching paste.
@@ -205,9 +171,9 @@ Upload your paste. It accept parameters in form-data:
 
 Explanation of the fields:
 
-- `url`: String. The URL to fetch the paste. When using a customized name, it looks like `https//shz.al/~myname`.
-- `manageUrl`: String. The URL to update and delete the paste, which is `url` suffixed by `~` and the password.
-- `expirationSeconds`: String. The expiration seconds.
+- `url`: String. The URL to fetch the paste. When using a customized name, it looks like `https://shz.al/~myname`.
+- `manageUrl`: String. The URL to update and delete the paste, which is `url` suffixed by `:` and the password.
+- `expirationSeconds`: Number. The expiration seconds.
 - `expireAt`: String. An ISO String representing when the paste will expire.
 
 If error occurs, the worker returns status code different from `200`:
@@ -217,39 +183,9 @@ If error occurs, the worker returns status code different from `200`:
 - `413`: the content is too large.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
 
-Usage example:
-
-```shell
-$ curl -Fc="kawaii" -Fe=300 -Fn=hitagi https://shz.al  # uploading some text
-{
-  "url": "https://shz.al/~hitagi",
-  "manageUrl": "https://shz.al/~hitagi:22@-OJWcTOH2jprTJWYadmDv",
-  "expirationSeconds": 300,
-  "expireAt": "2025-05-05T10:33:06.114Z"
-}
-
-$ curl -Fc=@panty.jpg -Fn=panty -Fs=12345678 https://shz.al   # uploading a file
-{
-  "url": "https://shz.al/~panty",
-  "manageUrl": "https://shz.al/~panty:12345678",
-  "expirationSeconds": 1209600,
-  "expireAt": "2025-05-05T10:33:06.114Z"
-}
-
-# because `curl` takes some characters as filed separator, the fields should be
-# quoted by double-quotes if the field contains semicolon or comma
-$ curl -Fc=@panty.jpg -Fn='"hi/hello;g,ood"' -Fs=12345678 https://shz.al
-{
-  "url": "https://shz.al/~hi/hello;g,ood",
-  "manageUrl": "https://shz.al/~hi/hello;g,ood:QJhMKh5WR6z36QRAAn5Q5GZh",
-  "expirationSeconds": 1209600,
-  "expireAt": "2025-05-05T10:33:06.114Z"
-}
-```
-
 ## **PUT** `/<name>:<passwd>`
 
-Update you paste of the name `<name>` and password `<passwd>`. It accept the parameters in form-data:
+Update your paste of the name `<name>` and password `<passwd>`. It accepts the parameters in form-data:
 
 - `c`: mandatory. Same as `POST` method.
 - `e`: optional. Same as `POST` method. Note that the deletion time is now recalculated.
@@ -265,26 +201,6 @@ If error occurs, the worker returns status code different from `200`:
 - `413`: the content is too large.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
 
-Usage example:
-
-```shell
-$ curl -X PUT -Fc="kawaii~" -Fe=500 https://shz.al/~hitagi:22@-OJWcTOH2jprTJWYadmDv
-{
-  "url": "https://shz.al/~hitagi",
-  "manageUrl": "https://shz.al/~hitagi:22@-OJWcTOH2jprTJWYadmDv",
-  "expirationSeconds": 500,
-  "expireAt": "2025-05-05T10:33:06.114Z"
-}
-
-$ curl -X PUT -Fc="kawaii~" https://shz.al/~hitagi:22@-OJWcTOH2jprTJWYadmDv
-{
-  "url": "https://shz.al/~hitagi",
-  "manageUrl": "https://shz.al/~hitagi:22@-OJWcTOH2jprTJWYadmDv",
-  "expirationSeconds": 500,
-  "expireAt": "2025-05-05T10:33:06.114Z"
-}
-```
-
 ## DELETE `/<name>:<passwd>`
 
 Delete the paste of name `<name>` and password `<passwd>`. It may take seconds to synchronize the deletion globally.
@@ -294,13 +210,3 @@ If error occurs, the worker returns status code different from `200`:
 - `403`: your password is not correct.
 - `404`: the paste of given name is not found.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
-
-Usage example:
-
-```shell
-$ curl -X DELETE https://shz.al/~hitagi:22@-OJWcTOH2jprTJWYadmDv
-the paste will be deleted in seconds
-
-$ curl https://shz.al/~hitagi
-not found
-```

--- a/doc/api.md
+++ b/doc/api.md
@@ -185,11 +185,7 @@ If error occurs, the worker returns status code different from `200`:
 
 ## **PUT** `/<name>:<passwd>`
 
-Update your paste of the name `<name>` and password `<passwd>`. It accepts the parameters in form-data:
-
-- `c`: mandatory. Same as `POST` method.
-- `e`: optional. Same as `POST` method. Note that the deletion time is now recalculated.
-- `s`: optional. Same as `POST` method.
+Update your paste of the name `<name>` and password `<passwd>`. It accepts all the same form-data fields as `POST` (`c`, `e`, `s`, `lang`, `encryption-scheme`) **except** `n` (the name cannot be changed; supplying it returns `400`) and `p` (silently ignored). When `e` is supplied, the expiration is recalculated from the update time.
 
 The returning of `PUT` method is the same as `POST` method.
 

--- a/doc/curl.md
+++ b/doc/curl.md
@@ -1,0 +1,257 @@
+# CLI Usage with `curl`
+
+A comprehensive guide to using this pastebin from the command line. For the
+full HTTP API reference, see [api.md]({{BASE_URL}}/doc/api).
+
+## Conventions
+
+- `<name>` — the random name (e.g. `abcd`) or custom name (prefixed with `~`,
+  e.g. `~hitagi`) of a paste.
+- `<passwd>` — the password returned at upload time, used to update or delete
+  the paste.
+- `<expire>` — an expiration period: an integer or float, optionally suffixed
+  with `s` (seconds, default), `m` (minutes), `h` (hours), or `d` (days). For
+  example, `300`, `30m`, `25d`.
+
+## Uploading
+
+### Upload text content
+
+```shell
+$ curl -Fc='hello, world' {{BASE_URL}}
+{
+  "url": "{{BASE_URL}}/abcd",
+  "manageUrl": "{{BASE_URL}}/abcd:w2eHqyZGc@CQzWLN=BiJiQxZ",
+  "expirationSeconds": 1209600,
+  "expireAt": "2026-05-21T10:33:06.114Z"
+}
+```
+
+Save `url` for sharing and `manageUrl` for later updates or deletion.
+
+### Upload a file
+
+```shell
+$ curl -Fc=@panty.jpg {{BASE_URL}}
+```
+
+The original filename will be sent back as the `Content-Disposition` header
+when the paste is fetched.
+
+### Upload from stdin
+
+```shell
+$ echo 'hello' | curl -Fc=@- {{BASE_URL}}
+$ cat panty.jpg | curl -Fc=@- {{BASE_URL}}
+```
+
+### Set an expiration
+
+```shell
+$ curl -Fc='kawaii' -Fe=300 {{BASE_URL}}      # 300 seconds
+$ curl -Fc='kawaii' -Fe=2h  {{BASE_URL}}      # 2 hours
+$ curl -Fc=@big.bin -Fe=30d {{BASE_URL}}      # 30 days
+```
+
+If `e` is not specified, the default expiration of the deployment is used. The
+maximum expiration is also enforced by the deployment.
+
+### Use a custom name
+
+```shell
+$ curl -Fc='kawaii' -Fn=hitagi {{BASE_URL}}
+{
+  "url": "{{BASE_URL}}/~hitagi",
+  ...
+}
+```
+
+The custom name is at least 3 characters long and may consist of letters,
+digits, and `+_-[]*$=@,;/`. Note the leading `~` in the returned URL.
+
+Because `curl` uses `;` and `,` as field separators, names containing those
+characters need to be wrapped in extra quotes:
+
+```shell
+$ curl -Fc=@panty.jpg -Fn='"hi/hello;g,ood"' {{BASE_URL}}
+```
+
+### Set a custom password
+
+```shell
+$ curl -Fc='kawaii' -Fs=12345678 {{BASE_URL}}
+```
+
+If `s` is omitted, a random password is generated and returned in `manageUrl`.
+
+### Private mode (longer random name)
+
+```shell
+$ curl -Fc='secret' -Fp=1 {{BASE_URL}}
+```
+
+Without a custom name (`n`), `p` produces a 24-character random name, making
+the paste effectively unguessable.
+
+### Mark a paste as syntax-highlighted
+
+```shell
+$ curl -Fc=@main.rs -Flang=rust {{BASE_URL}}
+```
+
+The `lang` field is sent back as the `X-PB-Highlight-Language` header on
+fetching the paste, and is used by the display page (`/d/<name>`).
+
+## Fetching
+
+### Fetch raw content
+
+```shell
+$ curl {{BASE_URL}}/abcd
+hello, world
+```
+
+### Save the response to a file
+
+```shell
+$ curl {{BASE_URL}}/~panty.jpg -o panty.jpg
+$ curl -OJ {{BASE_URL}}/~panty               # use server-supplied filename
+```
+
+`-J` honors the `Content-Disposition` header set from the original filename.
+
+### Force download (attachment)
+
+```shell
+$ curl '{{BASE_URL}}/abcd?a' -OJ
+```
+
+The `?a` query string sets `Content-Disposition: attachment`.
+
+### Override mime type
+
+```shell
+$ curl '{{BASE_URL}}/~panty.jpg?mime=image/png' \
+    -w '%{content_type}\n' -o /dev/null -sS
+image/png
+```
+
+Or via path extension:
+
+```shell
+$ curl '{{BASE_URL}}/abcd.json' -i
+```
+
+### Pipe to another tool
+
+```shell
+$ curl {{BASE_URL}}/~panty.jpg | feh -
+$ curl {{BASE_URL}}/~config | jq .
+```
+
+### Conditional fetch with `If-Modified-Since`
+
+```shell
+$ curl -i -H 'If-Modified-Since: Wed, 01 May 2026 00:00:00 GMT' \
+    {{BASE_URL}}/~hitagi
+HTTP/2 304
+```
+
+## Inspecting metadata
+
+```shell
+$ curl {{BASE_URL}}/m/abcd
+{
+  "lastModifiedAt": "2026-05-05T10:33:06.114Z",
+  "createdAt": "2026-05-01T10:33:06.114Z",
+  "expireAt": "2026-05-08T10:33:06.114Z",
+  "sizeBytes": 4096,
+  "location": "KV",
+  "filename": "a.jpg"
+}
+```
+
+A `HEAD` request returns the same headers as `GET` without the body, useful
+for quickly checking size and `Content-Type`:
+
+```shell
+$ curl -I {{BASE_URL}}/abcd
+```
+
+## URL shortener
+
+Upload a short URL, then redirect through `/u/<name>`:
+
+```shell
+$ curl -Fc='https://example.com/very/long/path' -Fn=ex {{BASE_URL}}
+$ curl -L {{BASE_URL}}/u/~ex
+```
+
+## Markdown rendering
+
+Upload a markdown file and render it as HTML via `/a/<name>`:
+
+```shell
+$ curl -Fc=@README.md -Fn=readme {{BASE_URL}}
+$ firefox {{BASE_URL}}/a/~readme
+```
+
+GitHub-flavored Markdown is supported, along with syntax highlighting and
+LaTeX math via MathJax.
+
+## Updating an existing paste
+
+Use the `manageUrl` returned at upload time:
+
+```shell
+$ curl -X PUT -Fc='kawaii~' \
+    {{BASE_URL}}/~hitagi:22@-OJWcTOH2jprTJWYadmDv
+```
+
+`PUT` accepts the same fields as `POST` (`c`, `e`, `s`). Note that `e`
+recalculates the expiration starting from the update time.
+
+## Deleting a paste
+
+```shell
+$ curl -X DELETE {{BASE_URL}}/~hitagi:22@-OJWcTOH2jprTJWYadmDv
+the paste will be deleted in seconds
+```
+
+Deletion may take a few seconds to propagate globally.
+
+## Tips
+
+- Pipe long output through `jq` to inspect upload responses:
+
+  ```shell
+  $ curl -sFc='hi' {{BASE_URL}} | jq -r .url
+  ```
+
+- Save the management URL into a variable to chain commands:
+
+  ```shell
+  $ resp=$(curl -sFc=@notes.md {{BASE_URL}})
+  $ url=$(jq  -r .url       <<<"$resp")
+  $ mgmt=$(jq -r .manageUrl  <<<"$resp")
+  ```
+
+- For files larger than the `R2_THRESHOLD` of the deployment, content is
+  stored in R2 instead of KV transparently — no client change is needed.
+
+- The maximum allowed upload size is set per deployment via `R2_MAX_ALLOWED`.
+  Exceeding it returns HTTP `413`.
+
+## Common errors
+
+| Status | Meaning                                                  |
+| -----: | -------------------------------------------------------- |
+|  `400` | Malformed request (bad field, illegal name, bad expire). |
+|  `403` | Wrong password when updating or deleting.                |
+|  `404` | Paste not found, or already expired.                     |
+|  `409` | Custom name is already in use.                           |
+|  `413` | Content exceeds the configured max size.                 |
+|  `500` | Unexpected server error — please report it.              |
+
+For the full HTTP API including `HEAD`, `OPTIONS`, response headers, and edge
+cases, see [api.md]({{BASE_URL}}/doc/api).

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,25 @@
+# Pastebin Worker
+
+A self-hosted pastebin running on Cloudflare Workers. Visit {{BASE_URL}} in a
+browser for the full UI, or use `curl` from the terminal.
+
+## Quick start
+
+```shell
+$ curl -Fc='hello, world' {{BASE_URL}}        # upload text
+$ curl -Fc=@file.txt      {{BASE_URL}}        # upload a file
+$ echo 'hello' | curl -Fc=@- {{BASE_URL}}     # upload from stdin
+```
+
+The response includes a `url` to share and a `manageUrl` for updates and
+deletion.
+
+## More
+
+```shell
+$ curl {{BASE_URL}}/doc/curl       # comprehensive curl usage
+$ curl {{BASE_URL}}/doc/api        # HTTP API reference
+$ curl {{BASE_URL}}/doc/tos        # terms of service
+```
+
+Source: {{REPO}}

--- a/frontend/pages/PasteBin.tsx
+++ b/frontend/pages/PasteBin.tsx
@@ -175,9 +175,13 @@ export function PasteBin({ config }: { config: Env }) {
       </div>
       <p className="my-2">An open source pastebin deployed on Cloudflare Workers. </p>
       <p className="my-2">
-        <b>Usage</b>: Paste text or file here. Upload. Share it with a URL. Or access with our{" "}
-        <Link className={tst} href={`${config.DEPLOY_URL}/api`}>
-          APIs
+        <b>Usage</b>: paste text or drop a file, then share the returned URL. You can also use{" "}
+        <Link className={tst} href={`${config.DEPLOY_URL}/doc/curl`}>
+          curl
+        </Link>
+        {" or the "}
+        <Link className={tst} href={`${config.DEPLOY_URL}/doc/api`}>
+          HTTP API
         </Link>
         .
       </p>
@@ -209,7 +213,7 @@ export function PasteBin({ config }: { config: Env }) {
   const footer = (
     <footer className="px-3 my-4 text-center">
       <p>
-        <Link href={`${config.DEPLOY_URL}/tos`} className={`d-inline-block ${tst}`}>
+        <Link href={`${config.DEPLOY_URL}/doc/tos`} className={`d-inline-block ${tst}`}>
           Terms & Conditions
         </Link>
         {" / "}

--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -1,5 +1,5 @@
 import { decode, isLegalUrl, WorkerError, escapeHtml } from "../common.js"
-import { getDocPage } from "../pages/docs.js"
+import { getDocMarkdown, getCurlIndexMarkdown, renderDocAsHtml } from "../pages/docs.js"
 import { verifyAuth } from "../pages/auth.js"
 import mime from "mime"
 import { makeMarkdown } from "../pages/markdown.js"
@@ -45,8 +45,29 @@ function lastModifiedHeader(metadata: PasteMetadata): Headers {
   return lastModified ? { "Last-Modified": new Date(lastModified * 1000).toUTCString() } : {}
 }
 
+function isCurlAgent(request: Request): boolean {
+  const ua = request.headers.get("User-Agent") || ""
+  return ua.toLowerCase().startsWith("curl/")
+}
+
 async function handleStaticPages(request: Request, env: Env, _: ExecutionContext): Promise<Response | null> {
   const url = new URL(request.url)
+  const isCurl = isCurlAgent(request)
+
+  // Serve doc/index.md as plain markdown when curl visits "/"
+  if (url.pathname === "/" && isCurl) {
+    const authResponse = verifyAuth(request, env)
+    if (authResponse !== null) {
+      return authResponse
+    }
+    return new Response(getCurlIndexMarkdown(env), {
+      headers: {
+        "Content-Type": "text/plain;charset=UTF-8",
+        Vary: "User-Agent",
+        ...staticPageCacheHeader(env),
+      },
+    })
+  }
 
   let path = url.pathname
   if (path.endsWith("/")) {
@@ -131,14 +152,18 @@ ${DARK_MODE_SCRIPT}
     }
   }
 
-  const staticPageContent = getDocPage(url.pathname, env)
-  if (staticPageContent) {
-    return new Response(staticPageContent, {
-      headers: {
-        "Content-Type": "text/html;charset=UTF-8",
-        ...staticPageCacheHeader(env),
-      },
-    })
+  if (url.pathname === "/doc" || url.pathname.startsWith("/doc/")) {
+    const docMd = getDocMarkdown(url.pathname, env)
+    if (docMd !== null) {
+      return new Response(isCurl ? docMd : renderDocAsHtml(docMd), {
+        headers: {
+          "Content-Type": isCurl ? "text/plain;charset=UTF-8" : "text/html;charset=UTF-8",
+          Vary: "User-Agent",
+          ...staticPageCacheHeader(env),
+        },
+      })
+    }
+    throw new WorkerError(404, `doc page '${url.pathname}' not found`)
   }
 
   return null

--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -54,8 +54,8 @@ async function handleStaticPages(request: Request, env: Env, _: ExecutionContext
   const url = new URL(request.url)
   const isCurl = isCurlAgent(request)
 
-  // Serve doc/index.md as plain markdown when curl visits "/"
-  if (url.pathname === "/" && isCurl) {
+  // Serve doc/index.md as plain markdown for curl on "/" or anyone on "/index.md"
+  if ((url.pathname === "/" && isCurl) || url.pathname === "/index.md") {
     const authResponse = verifyAuth(request, env)
     if (authResponse !== null) {
       return authResponse
@@ -153,11 +153,14 @@ ${DARK_MODE_SCRIPT}
   }
 
   if (url.pathname === "/doc" || url.pathname.startsWith("/doc/")) {
-    const docMd = getDocMarkdown(url.pathname, env)
+    const isExplicitMd = url.pathname.endsWith(".md")
+    const lookupPath = isExplicitMd ? url.pathname.slice(0, -3) : url.pathname
+    const docMd = getDocMarkdown(lookupPath, env)
     if (docMd !== null) {
-      return new Response(isCurl ? docMd : renderDocAsHtml(docMd), {
+      const wantsMarkdown = isExplicitMd || isCurl
+      return new Response(wantsMarkdown ? docMd : renderDocAsHtml(docMd), {
         headers: {
-          "Content-Type": isCurl ? "text/plain;charset=UTF-8" : "text/html;charset=UTF-8",
+          "Content-Type": wantsMarkdown ? "text/plain;charset=UTF-8" : "text/html;charset=UTF-8",
           Vary: "User-Agent",
           ...staticPageCacheHeader(env),
         },

--- a/worker/pages/docs.ts
+++ b/worker/pages/docs.ts
@@ -2,18 +2,33 @@ import { makeMarkdown } from "./markdown.js"
 
 import tosMd from "../../doc/tos.md"
 import apiMd from "../../doc/api.md"
+import curlMd from "../../doc/curl.md"
+import indexMd from "../../doc/index.md"
 
-export function getDocPage(path: string, env: Env): string | null {
-  if (path === "/tos" || path === "/tos.html") {
-    const tosMdRenderred = tosMd
-      .replaceAll("{{TOS_MAINTAINER}}", env.TOS_MAINTAINER)
-      .replaceAll("{{TOS_MAIL}}", env.TOS_MAIL)
-      .replaceAll("{{BASE_URL}}", env.DEPLOY_URL)
+function renderTemplate(template: string, env: Env): string {
+  return template
+    .replaceAll("{{BASE_URL}}", env.DEPLOY_URL)
+    .replaceAll("{{REPO}}", env.REPO)
+    .replaceAll("{{TOS_MAINTAINER}}", env.TOS_MAINTAINER)
+    .replaceAll("{{TOS_MAIL}}", env.TOS_MAIL)
+}
 
-    return makeMarkdown(tosMdRenderred)
-  } else if (path === "/api" || path === "/api.html") {
-    return makeMarkdown(apiMd)
+export function getDocMarkdown(path: string, env: Env): string | null {
+  if (path === "/doc/tos" || path === "/doc/tos.html") {
+    return renderTemplate(tosMd, env)
+  } else if (path === "/doc/api" || path === "/doc/api.html") {
+    return renderTemplate(apiMd, env)
+  } else if (path === "/doc/curl" || path === "/doc/curl.html") {
+    return renderTemplate(curlMd, env)
   } else {
     return null
   }
+}
+
+export function getCurlIndexMarkdown(env: Env): string {
+  return renderTemplate(indexMd, env)
+}
+
+export function renderDocAsHtml(md: string): string {
+  return makeMarkdown(md)
 }

--- a/worker/test/basicAuth.spec.ts
+++ b/worker/test/basicAuth.spec.ts
@@ -46,6 +46,11 @@ describe("basic auth", () => {
     }
   })
 
+  it("should forbid accessing curl index without auth", async () => {
+    const resp = await workerFetch(ctx, new Request(BASE_URL, { headers: { "User-Agent": "curl/8.0.0" } }))
+    expect(resp.status).toStrictEqual(401)
+  })
+
   it("should allow accessing index without auth", async () => {
     expect((await workerFetch(ctx, new Request(BASE_URL, { headers: authHeader }))).status).toStrictEqual(200)
   })
@@ -80,7 +85,7 @@ describe("basic auth", () => {
   })
 
   it("should allow accessing doc pages without auth", async () => {
-    for (const page of ["/api", "/tos"]) {
+    for (const page of ["/doc/api", "/doc/tos", "/doc/curl"]) {
       expect((await workerFetch(ctx, `${BASE_URL}${page}`)).status, `visiting ${page}`).toStrictEqual(200)
     }
   })

--- a/worker/test/basicAuth.spec.ts
+++ b/worker/test/basicAuth.spec.ts
@@ -41,7 +41,7 @@ describe("basic auth", () => {
   })
 
   it("should forbid accessing index without auth", async () => {
-    for (const page of ["", "index", "index.html"]) {
+    for (const page of ["", "index", "index.html", "index.md"]) {
       expect((await workerFetch(ctx, `${BASE_URL}/${page}`)).status, `visiting ${page}`).toStrictEqual(401)
     }
   })

--- a/worker/test/docPages.spec.ts
+++ b/worker/test/docPages.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { createExecutionContext } from "cloudflare:test"
+
+import { BASE_URL, workerFetch } from "./testUtils.js"
+
+const curlHeaders = { "User-Agent": "curl/8.0.0" }
+const browserHeaders = {
+  "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+}
+
+describe("doc pages", () => {
+  const ctx = createExecutionContext()
+
+  it("returns rendered HTML to browsers", async () => {
+    for (const page of ["/doc/api", "/doc/tos", "/doc/curl"]) {
+      const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: browserHeaders }))
+      expect(resp.status, `visiting ${page}`).toStrictEqual(200)
+      expect(resp.headers.get("Content-Type")).toStrictEqual("text/html;charset=UTF-8")
+      const body = await resp.text()
+      expect(body.startsWith("<!DOCTYPE html>"), `body of ${page} should be HTML`).toStrictEqual(true)
+    }
+  })
+
+  it("returns raw markdown to curl", async () => {
+    for (const page of ["/doc/api", "/doc/tos", "/doc/curl"]) {
+      const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: curlHeaders }))
+      expect(resp.status, `visiting ${page}`).toStrictEqual(200)
+      expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+      expect(resp.headers.get("Vary")).toStrictEqual("User-Agent")
+      const body = await resp.text()
+      expect(body.startsWith("<!DOCTYPE html>"), `body of ${page} should be markdown`).toStrictEqual(false)
+    }
+  })
+
+  it("returns 404 for unknown doc paths", async () => {
+    for (const page of ["/doc", "/doc/", "/doc/missing", "/doc/cli"]) {
+      const resp = await workerFetch(ctx, `${BASE_URL}${page}`)
+      expect(resp.status, `visiting ${page}`).toStrictEqual(404)
+      expect(await resp.text(), `visiting ${page}`).toContain("doc page")
+    }
+  })
+
+  it("expands {{BASE_URL}} in doc bodies", async () => {
+    const resp = await workerFetch(ctx, new Request(`${BASE_URL}/doc/curl`, { headers: curlHeaders }))
+    const body = await resp.text()
+    expect(body.includes("{{BASE_URL}}"), "template should be expanded").toStrictEqual(false)
+    expect(body.includes(BASE_URL), "should contain DEPLOY_URL").toStrictEqual(true)
+  })
+
+  it("serves doc/index.md as markdown to curl on /", async () => {
+    const resp = await workerFetch(ctx, new Request(BASE_URL, { headers: curlHeaders }))
+    expect(resp.status).toStrictEqual(200)
+    expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+    expect(resp.headers.get("Vary")).toStrictEqual("User-Agent")
+    const body = await resp.text()
+    expect(body.includes("# Pastebin Worker"), "body should contain index heading").toStrictEqual(true)
+    expect(body.includes("{{BASE_URL}}"), "template should be expanded").toStrictEqual(false)
+  })
+
+  it("serves the SPA to browsers on /", async () => {
+    const resp = await workerFetch(ctx, new Request(BASE_URL, { headers: browserHeaders }))
+    expect(resp.status).toStrictEqual(200)
+    expect(resp.headers.get("Content-Type")).toStrictEqual("text/html;charset=UTF-8")
+  })
+})

--- a/worker/test/docPages.spec.ts
+++ b/worker/test/docPages.spec.ts
@@ -33,11 +33,30 @@ describe("doc pages", () => {
   })
 
   it("returns 404 for unknown doc paths", async () => {
-    for (const page of ["/doc", "/doc/", "/doc/missing", "/doc/cli"]) {
+    for (const page of ["/doc", "/doc/", "/doc/missing", "/doc/cli", "/doc/missing.md"]) {
       const resp = await workerFetch(ctx, `${BASE_URL}${page}`)
       expect(resp.status, `visiting ${page}`).toStrictEqual(404)
       expect(await resp.text(), `visiting ${page}`).toContain("doc page")
     }
+  })
+
+  it("serves markdown to any UA on /doc/<name>.md", async () => {
+    for (const page of ["/doc/api.md", "/doc/tos.md", "/doc/curl.md"]) {
+      const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: browserHeaders }))
+      expect(resp.status, `visiting ${page}`).toStrictEqual(200)
+      expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+      const body = await resp.text()
+      expect(body.startsWith("<!DOCTYPE html>"), `body of ${page} should be markdown`).toStrictEqual(false)
+    }
+  })
+
+  it("serves /index.md as markdown to any UA", async () => {
+    const resp = await workerFetch(ctx, new Request(`${BASE_URL}/index.md`, { headers: browserHeaders }))
+    expect(resp.status).toStrictEqual(200)
+    expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+    const body = await resp.text()
+    expect(body.includes("# Pastebin Worker")).toStrictEqual(true)
+    expect(body.includes("{{BASE_URL}}")).toStrictEqual(false)
   })
 
   it("expands {{BASE_URL}} in doc bodies", async () => {

--- a/worker/test/testUtils.ts
+++ b/worker/test/testUtils.ts
@@ -13,12 +13,16 @@ export const staticPages = [
   "",
   "index.html",
   "index",
+  "index.md",
   "doc/tos",
   "doc/tos.html",
+  "doc/tos.md",
   "doc/api",
   "doc/api.html",
+  "doc/api.md",
   "doc/curl",
   "doc/curl.html",
+  "doc/curl.md",
   "favicon.ico",
 ]
 

--- a/worker/test/testUtils.ts
+++ b/worker/test/testUtils.ts
@@ -9,7 +9,18 @@ import type { PasteResponse } from "../../shared/interfaces.js"
 export const BASE_URL: string = env.DEPLOY_URL
 export const RAND_NAME_REGEX = /^[ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678]+$/
 
-export const staticPages = ["", "index.html", "index", "tos", "tos.html", "api", "api.html", "favicon.ico"]
+export const staticPages = [
+  "",
+  "index.html",
+  "index",
+  "doc/tos",
+  "doc/tos.html",
+  "doc/api",
+  "doc/api.html",
+  "doc/curl",
+  "doc/curl.html",
+  "favicon.ico",
+]
 
 type FormDataBuild = Record<string, string | Blob | { content: Blob; filename: string }>
 


### PR DESCRIPTION
Adds doc/curl.md (comprehensive curl usage) and doc/index.md (brief
intro), moves doc routes under /doc/{api,tos,curl} so the names are
free for pastes, and returns a direct 404 for unknown /doc/* paths.
When the User-Agent starts with curl/, / and /doc/* respond with
raw markdown (text/plain) instead of HTML; Vary: User-Agent is set
so shared caches do not poison across UAs, and the curl / branch
runs verifyAuth so BASIC_AUTH still applies. Also fixes several
factual errors and typos in doc/api.md and freshens the frontend
usage copy.

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
