### PR TITLE
More tests

### DIFF
--- a/frontend/test/crypto.spec.ts
+++ b/frontend/test/crypto.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { encrypt, decrypt, genKey, encodeKey, decodeKey } from "../utils/encryption.js"
+import type { EncryptionScheme } from "../utils/encryption.js"
 import { genRandStr } from "../../worker/common.js"
 
 function randArray(len: number): Uint8Array {
@@ -54,5 +55,30 @@ describe("encrypt with AES-GCM", () => {
         expect(plaintext[i], `${i}-th bit of decrypted`).toStrictEqual(decryptedBuffer![i])
       }
     }
+  })
+})
+
+describe("unsupported scheme throws", () => {
+  // simulate a future or corrupted scheme value reaching crypto helpers
+  const bad = "RC4" as unknown as EncryptionScheme
+
+  it("genKey rejects unknown scheme", async () => {
+    await expect(genKey(bad)).rejects.toThrow(/Unsupported encryption scheme: RC4/)
+  })
+
+  it("encrypt rejects unknown scheme", async () => {
+    const key = await genKey("AES-GCM")
+    await expect(encrypt(bad, key, new Uint8Array([1, 2, 3]))).rejects.toThrow(/Unsupported encryption scheme: RC4/)
+  })
+
+  it("decrypt rejects unknown scheme", async () => {
+    const key = await genKey("AES-GCM")
+    await expect(decrypt(bad, key, new Uint8Array([1, 2, 3]))).rejects.toThrow(/Unsupported encryption scheme: RC4/)
+  })
+
+  it("decodeKey rejects unknown scheme", async () => {
+    const key = await genKey("AES-GCM")
+    const encoded = await encodeKey(key)
+    await expect(decodeKey(bad, encoded)).rejects.toThrow(/Unsupported encryption scheme: RC4/)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         version: 7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
       wrangler:
         specifier: ^4.89.1
         version: 4.89.1
@@ -247,6 +247,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -633,89 +637,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -866,66 +886,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1005,24 +1038,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -1228,6 +1265,15 @@ packages:
     peerDependencies:
       vitest: 4.1.5
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1296,6 +1342,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1712,6 +1761,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1798,24 +1850,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2771,6 +2827,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2':
+    optional: true
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -2790,7 +2849,7 @@ snapshots:
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260507.1
-      vitest: 4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      vitest: 4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
       wrangler: 4.89.1
       zod: 3.25.76
     transitivePeerDependencies:
@@ -3572,9 +3631,24 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      vitest: 4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
+    optional: true
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -3648,6 +3722,13 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+    optional: true
 
   bail@2.0.2: {}
 
@@ -4054,6 +4135,9 @@ snapshots:
       istanbul-lib-report: 3.0.1
 
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -4998,7 +5082,7 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vitest@4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitest@4.1.5(@types/node@25.6.1)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.14.4(@types/node@25.6.1)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.1)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -5023,6 +5107,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.1
       '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/shared/parsers.ts
+++ b/shared/parsers.ts
@@ -8,8 +8,8 @@ export class ParseError extends Error {
 
 export function parseSize(sizeStr: string): number | null {
   sizeStr = sizeStr.trim()
-  const EXPIRE_REGEX = /^[\d.]+\s*[KMG]?$/
-  if (!EXPIRE_REGEX.test(sizeStr)) {
+  const SIZE_REGEX = /^\d+(\.\d+)?\s*[KMG]?$/
+  if (!SIZE_REGEX.test(sizeStr)) {
     return null
   }
 
@@ -23,16 +23,12 @@ export function parseSize(sizeStr: string): number | null {
 
 export function parseExpiration(expirationStr: string): number | null {
   expirationStr = expirationStr.trim()
-  const EXPIRE_REGEX = /^[\d.]+\s*[smhd]?$/
+  const EXPIRE_REGEX = /^\d+(\.\d+)?\s*[smhd]?$/
   if (!EXPIRE_REGEX.test(expirationStr)) {
     return null
   }
 
   let expirationSeconds = parseFloat(expirationStr)
-  if (isNaN(expirationSeconds)) {
-    return null
-  }
-
   const lastChar = expirationStr[expirationStr.length - 1]
   if (lastChar === "m") expirationSeconds *= 60
   else if (lastChar === "h") expirationSeconds *= 3600
@@ -42,15 +38,12 @@ export function parseExpiration(expirationStr: string): number | null {
 
 export function parseExpirationReadable(expirationStr: string): string | null {
   expirationStr = expirationStr.trim()
-  const EXPIRE_REGEX = /^[\d.]+\s*[smhd]?$/
+  const EXPIRE_REGEX = /^\d+(\.\d+)?\s*[smhd]?$/
   if (!EXPIRE_REGEX.test(expirationStr)) {
     return null
   }
 
   const num = parseFloat(expirationStr)
-  if (isNaN(num)) {
-    return null
-  }
   const lastChar = expirationStr[expirationStr.length - 1]
   if (lastChar === "m") return `${num} minute${num > 1 ? "s" : ""}`
   else if (lastChar === "h") return `${num} hour${num > 1 ? "s" : ""}`

--- a/shared/test/parser.spec.ts
+++ b/shared/test/parser.spec.ts
@@ -6,6 +6,7 @@ import {
   parseFilenameFromContentDisposition,
   parseExpiration,
   parseExpirationReadable,
+  parseSize,
 } from "../parsers.js"
 
 test("parsePath", () => {
@@ -45,14 +46,52 @@ test("parsePath throws on empty name", () => {
 })
 
 test("parseFilenameFromContentDisposition", () => {
-  const testPairs: [string, string][] = [
+  const testPairs: [string, string | undefined][] = [
     [`inline; filename="abc.jpg"`, "abc.jpg"],
     [`inline; filename*=UTF-8''${encodeURIComponent("abc.jpg")}`, "abc.jpg"],
     [`inline; filename*=UTF-8''${encodeURIComponent("りんご")}`, "りんご"],
+    // filename* takes precedence over filename when both present
+    [`inline; filename="ascii.jpg"; filename*=UTF-8''${encodeURIComponent("りんご.jpg")}`, "りんご.jpg"],
+    // attachment instead of inline; only quoted filename
+    [`attachment; filename="report.pdf"`, "report.pdf"],
+    // no filename hint at all
+    [`inline`, undefined],
+    [``, undefined],
   ]
   for (const [input, output] of testPairs) {
     const parsed = parseFilenameFromContentDisposition(input)
     expect(parsed, `checking filename of ${input}`).toStrictEqual(output)
+  }
+})
+
+test("parseSize", () => {
+  const testPairs: [string, number | null][] = [
+    ["0", 0],
+    ["1024", 1024],
+    ["1K", 1024],
+    ["1M", 1024 * 1024],
+    ["1G", 1024 * 1024 * 1024],
+    ["1.5K", 1536],
+    ["10 K", 10 * 1024],
+    [" 10 K ", 10 * 1024],
+
+    // invalid: lowercase suffix not accepted
+    ["1k", null],
+    ["1m", null],
+    // invalid: malformed number
+    ["1.1.1K", null],
+    ["1.K", null],
+    [".5K", null],
+    ["abc", null],
+    ["", null],
+    // invalid: negative
+    ["-1K", null],
+    // invalid: stray suffix
+    ["1KB", null],
+    ["1T", null],
+  ]
+  for (const [input, expected] of testPairs) {
+    expect(parseSize(input), `checking size of ${JSON.stringify(input)}`).toStrictEqual(expected)
   }
 })
 

--- a/shared/test/uploadPaste.spec.ts
+++ b/shared/test/uploadPaste.spec.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { UploadError, uploadMPU, uploadNormal } from "../uploadPaste.js"
+
+const API_URL = "https://example.com"
+
+function jsonResp(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    ...init,
+    headers: { "content-type": "application/json", ...(init.headers || {}) },
+  })
+}
+
+function makeFile(size: number, name = "blob"): File {
+  return new File([new Uint8Array(size)], name)
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("UploadError", () => {
+  it("stores status code on instance", () => {
+    const err = new UploadError(418, "I'm a teapot")
+    expect(err).toBeInstanceOf(Error)
+    expect(err.statusCode).toStrictEqual(418)
+    expect(err.message).toStrictEqual("I'm a teapot")
+  })
+})
+
+type FetchCall = [input: string | URL, init: RequestInit]
+
+describe("uploadNormal", () => {
+  it("POSTs to apiUrl on create and returns parsed json", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResp({ url: "https://example.com/abcd", manageUrl: "https://example.com/abcd:pw" }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const resp = await uploadNormal(API_URL, {
+      content: makeFile(16, "x.txt"),
+      isUpdate: false,
+      isPrivate: true,
+      password: "pw",
+      name: "abcd",
+      highlightLanguage: "ts",
+      encryptionScheme: "AES-GCM",
+      expire: "10m",
+    })
+
+    expect(resp.url).toStrictEqual("https://example.com/abcd")
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [target, init] = fetchMock.mock.calls[0] as FetchCall
+    expect(target).toStrictEqual(API_URL)
+    expect(init.method).toStrictEqual("POST")
+
+    const fd = init.body as FormData
+    expect(fd.get("e")).toStrictEqual("10m")
+    expect(fd.get("s")).toStrictEqual("pw")
+    expect(fd.get("n")).toStrictEqual("abcd")
+    expect(fd.get("encryption-scheme")).toStrictEqual("AES-GCM")
+    expect(fd.get("lang")).toStrictEqual("ts")
+    expect(fd.get("p")).toStrictEqual("1")
+    expect(fd.get("c")).toBeInstanceOf(File)
+  })
+
+  it("PUTs to manageUrl on update and skips name field", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(jsonResp({ url: "u", manageUrl: "m" }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await uploadNormal(API_URL, {
+      content: makeFile(8),
+      isUpdate: true,
+      manageUrl: "https://example.com/abcd:pw",
+      name: "abcd", // should be ignored on update
+    })
+
+    const [target, init] = fetchMock.mock.calls[0] as FetchCall
+    expect(target).toStrictEqual("https://example.com/abcd:pw")
+    expect(init.method).toStrictEqual("PUT")
+    expect((init.body as FormData).get("n")).toBeNull()
+  })
+
+  it("throws TypeError when isUpdate without manageUrl", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(uploadNormal(API_URL, { content: makeFile(8), isUpdate: true })).rejects.toBeInstanceOf(TypeError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("throws UploadError carrying statusCode on non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response("bad name", { status: 400 })))
+
+    const err: unknown = await uploadNormal(API_URL, {
+      content: makeFile(8),
+      isUpdate: false,
+    }).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(UploadError)
+    expect((err as UploadError).statusCode).toStrictEqual(400)
+    expect((err as UploadError).message).toStrictEqual("bad name")
+  })
+})
+
+describe("uploadMPU", () => {
+  function setupHappyPath(numParts: number, complete = { url: "u", manageUrl: "m" }) {
+    const calls: { url: string; method: string; body?: BodyInit | null }[] = []
+    const partResponses: R2UploadedPart[] = Array.from({ length: numParts }, (_, i) => ({
+      partNumber: i + 1,
+      etag: `etag${i + 1}`,
+    }))
+    let partIdx = 0
+    const fetchMock = vi.fn<typeof fetch>((input, init = {}) => {
+      const url = input instanceof URL ? input.toString() : (input as string)
+      calls.push({ url, method: init.method || "GET", body: init.body as BodyInit | null })
+      if (url.includes("/mpu/create")) {
+        return Promise.resolve(jsonResp({ name: "~abcd", key: "k", uploadId: "uid" }))
+      }
+      if (url.includes("/mpu/resume")) {
+        return Promise.resolve(jsonResp(partResponses[partIdx++]))
+      }
+      if (url.includes("/mpu/complete")) {
+        return Promise.resolve(jsonResp(complete))
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`))
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    return { calls, fetchMock }
+  }
+
+  it("uploads in chunks, calls progress callback, and forwards optional fields on complete", async () => {
+    const { calls } = setupHappyPath(3)
+
+    const progress = vi.fn()
+    await uploadMPU(
+      API_URL,
+      4,
+      {
+        content: makeFile(10, "file.bin"),
+        isUpdate: false,
+        name: "abcd",
+        isPrivate: true,
+        password: "pw",
+        highlightLanguage: "rust",
+        encryptionScheme: "AES-GCM",
+        expire: "1d",
+      },
+      progress,
+    )
+
+    expect(progress).toHaveBeenCalledTimes(3)
+    expect(progress.mock.calls[0]).toEqual([4, 10])
+    expect(progress.mock.calls[1]).toEqual([8, 10])
+    expect(progress.mock.calls[2]).toEqual([10, 10])
+
+    const create = calls[0]
+    expect(create.method).toStrictEqual("POST")
+    expect(create.url).toContain("/mpu/create")
+    expect(create.url).toContain("n=abcd")
+    expect(create.url).toContain("p=1")
+    expect(create.url).toContain("e=1d")
+
+    expect(calls[1].method).toStrictEqual("PUT")
+    expect(calls[1].url).toContain("/mpu/resume")
+    expect(calls[1].url).toContain("partNumber=1")
+    expect(calls[3].url).toContain("partNumber=3")
+
+    const complete = calls[4]
+    expect(complete.url).toContain("/mpu/complete")
+    expect(complete.method).toStrictEqual("POST")
+    const fd = complete.body as FormData
+    expect(fd.get("e")).toStrictEqual("1d")
+    expect(fd.get("s")).toStrictEqual("pw")
+    expect(fd.get("lang")).toStrictEqual("rust")
+    expect(fd.get("encryption-scheme")).toStrictEqual("AES-GCM")
+  })
+
+  it("uses create-update endpoint and PUT on update with manageUrl password", async () => {
+    const { calls } = setupHappyPath(1)
+
+    await uploadMPU(API_URL, 16, {
+      content: makeFile(4),
+      isUpdate: true,
+      manageUrl: "https://example.com/abcd:secretpw",
+    })
+
+    expect(calls[0].url).toContain("/mpu/create-update")
+    expect(calls[0].url).toContain("name=abcd")
+    expect(calls[0].url).toContain("password=secretpw")
+    expect(calls[2].method).toStrictEqual("PUT")
+    expect(calls[2].url).toContain("/mpu/complete")
+  })
+
+  it("throws TypeError when isUpdate without manageUrl", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(uploadMPU(API_URL, 4, { content: makeFile(4), isUpdate: true })).rejects.toBeInstanceOf(TypeError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("throws TypeError when manageUrl has no password", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      uploadMPU(API_URL, 4, {
+        content: makeFile(4),
+        isUpdate: true,
+        manageUrl: "https://example.com/abcd",
+      }),
+    ).rejects.toBeInstanceOf(TypeError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("throws UploadError when create returns non-ok", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response("name in use", { status: 409 })))
+
+    const err: unknown = await uploadMPU(API_URL, 4, {
+      content: makeFile(4),
+      isUpdate: false,
+    }).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(UploadError)
+    expect((err as UploadError).statusCode).toStrictEqual(409)
+  })
+
+  it("throws UploadError when a chunk upload returns non-ok", async () => {
+    let call = 0
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(() => {
+        call++
+        if (call === 1) return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
+        return Promise.resolve(new Response("part failed", { status: 500 }))
+      }),
+    )
+
+    const err: unknown = await uploadMPU(API_URL, 4, {
+      content: makeFile(8),
+      isUpdate: false,
+    }).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(UploadError)
+    expect((err as UploadError).statusCode).toStrictEqual(500)
+  })
+
+  it("throws UploadError when complete returns non-ok", async () => {
+    let call = 0
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(() => {
+        call++
+        if (call === 1) return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
+        if (call === 2) return Promise.resolve(jsonResp({ partNumber: 1, etag: "e" }))
+        return Promise.resolve(new Response("complete failed", { status: 502 }))
+      }),
+    )
+
+    const err: unknown = await uploadMPU(API_URL, 8, {
+      content: makeFile(4),
+      isUpdate: false,
+    }).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(UploadError)
+    expect((err as UploadError).statusCode).toStrictEqual(502)
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     coverage: {
       provider: "istanbul", // v8 is not supported due for cf workers
       reporter: ["text", "json-summary", "html", "json"],
+      exclude: ["**/test/**"],
     },
     projects: [
       defineConfig({
@@ -22,6 +23,7 @@ export default defineConfig({
           coverage: {
             provider: "istanbul", // v8 is not supported due for cf workers
             reporter: ["text", "json-summary", "html", "json"],
+            exclude: ["**/test/**"],
           },
         },
       }),
@@ -34,6 +36,19 @@ export default defineConfig({
           coverage: {
             provider: "istanbul",
             reporter: ["text", "json-summary", "html", "json"],
+            exclude: ["**/test/**"],
+          },
+        },
+      },
+      {
+        test: {
+          include: ["shared/test/**/*.spec.ts"],
+          name: "Shared",
+          environment: "node",
+          coverage: {
+            provider: "istanbul",
+            reporter: ["text", "json-summary", "html", "json"],
+            exclude: ["**/test/**"],
           },
         },
       },

--- a/worker/handlers/handleMPU.ts
+++ b/worker/handlers/handleMPU.ts
@@ -26,7 +26,7 @@ export async function handleMPUCreate(request: Request, env: Env): Promise<Respo
       throw new WorkerError(400, `illegal paste name ‘${n}’ for MPU create`)
     }
     name = "~" + n
-    if (!(await pasteNameAvailable(env, n))) {
+    if (!(await pasteNameAvailable(env, name))) {
       throw new WorkerError(409, `name ‘${name}’ is already used`)
     }
   } else {

--- a/worker/handlers/handleWrite.ts
+++ b/worker/handlers/handleWrite.ts
@@ -77,11 +77,11 @@ export async function handlePostOrPut(
 
   let isMPUComplete = false
   if (url.pathname === "/mpu/create" && !isPut) {
-    return handleMPUCreate(request, env)
+    return await handleMPUCreate(request, env)
   } else if (url.pathname === "/mpu/create-update" && !isPut) {
-    return handleMPUCreateUpdate(request, env)
+    return await handleMPUCreateUpdate(request, env)
   } else if (url.pathname === "/mpu/resume" && isPut) {
-    return handleMPUResume(request, env)
+    return await handleMPUResume(request, env)
   } else if (url.pathname === "/mpu/complete") {
     isMPUComplete = true // we will handle mpu complete later since it is uploaded with formdata
   } else if (url.pathname.startsWith("/mpu/")) {

--- a/worker/test/mpuErrors.spec.ts
+++ b/worker/test/mpuErrors.spec.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createExecutionContext, env } from "cloudflare:test"
+import { BASE_URL, genRandomBlob, upload, workerFetch } from "./testUtils.js"
+import { parsePath } from "../../shared/parsers.js"
+import { uploadMPU } from "../../shared/uploadPaste.js"
+import worker from "../index.js"
+import type { MPUCreateResponse } from "../../shared/interfaces.js"
+
+const ctx = createExecutionContext()
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("MPU error paths", () => {
+  it("handleMPUCreate rejects names not matching NAME_REGEX", async () => {
+    // too short (regex requires {3,})
+    const r1 = await workerFetch(ctx, new Request(`${BASE_URL}/mpu/create?n=ab`, { method: "POST" }))
+    expect(r1.status).toStrictEqual(400)
+    expect(await r1.text()).toContain("illegal paste name")
+
+    // contains a character outside the allowed set
+    const r2 = await workerFetch(ctx, new Request(`${BASE_URL}/mpu/create?n=ab!cd`, { method: "POST" }))
+    expect(r2.status).toStrictEqual(400)
+  })
+
+  it("handleMPUCreate returns 409 when name is already taken", async () => {
+    const name = "mpuname"
+    await upload(ctx, { c: new Blob(["seed"]), n: name })
+
+    const resp = await workerFetch(ctx, new Request(`${BASE_URL}/mpu/create?n=${name}`, { method: "POST" }))
+    expect(resp.status).toStrictEqual(409)
+    expect(await resp.text()).toContain("already used")
+  })
+
+  it("handleMPUCreateUpdate requires both name and password", async () => {
+    const r1 = await workerFetch(ctx, new Request(`${BASE_URL}/mpu/create-update?name=foo`, { method: "POST" }))
+    expect(r1.status).toStrictEqual(400)
+
+    const r2 = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/create-update?password=secretpw`, { method: "POST" }),
+    )
+    expect(r2.status).toStrictEqual(400)
+  })
+
+  it("handleMPUCreateUpdate returns 404 for unknown paste", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/create-update?name=nonexist&password=whateverpw`, { method: "POST" }),
+    )
+    expect(resp.status).toStrictEqual(404)
+  })
+
+  it("handleMPUCreateUpdate returns 403 on incorrect password", async () => {
+    const seeded = await upload(ctx, { c: new Blob(["seed"]) })
+    const { name } = parsePath(new URL(seeded.url).pathname)
+
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/create-update?name=${name}&password=wrongpasswd`, { method: "POST" }),
+    )
+    expect(resp.status).toStrictEqual(403)
+  })
+
+  it("handleMPUResume requires partNumber, uploadId, and key", async () => {
+    const resp = await workerFetch(ctx, new Request(`${BASE_URL}/mpu/resume`, { method: "PUT", body: "x" }))
+    expect(resp.status).toStrictEqual(400)
+    expect(await resp.text()).toContain("missing")
+  })
+
+  it("handleMPUResume rejects request without a body", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/resume?key=k&uploadId=u&partNumber=1`, { method: "PUT" }),
+    )
+    expect(resp.status).toStrictEqual(400)
+    expect(await resp.text()).toContain("missing request body")
+  })
+
+  it("handleMPUComplete returns 400 when name does not match the upload key", async () => {
+    const createResp = await workerFetch(ctx, new Request(`${BASE_URL}/mpu/create`, { method: "POST" }))
+    const { key, uploadId }: MPUCreateResponse = await createResp.json()
+
+    // call complete with a name different from the key (no parts uploaded — the name check runs first)
+    const fd = new FormData()
+    fd.set("c", new File([JSON.stringify([])], "parts.json"))
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/complete?name=mismatched&key=${key}&uploadId=${uploadId}`, {
+        method: "POST",
+        body: fd,
+      }),
+    )
+    expect(resp.status).toStrictEqual(400)
+    expect(await resp.text()).toContain("not consistent")
+  })
+
+  it("handleMPUComplete returns 413 when uploaded object exceeds R2_MAX_ALLOWED", async () => {
+    const tightEnv = { ...env, R2_MAX_ALLOWED: "1K" }
+
+    // Route create/resume through default env so chunks pass; only the complete request uses
+    // the tight env, so the small parts-JSON formdata still fits within 1K but the assembled R2
+    // object trips the size check.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit<RequestInitCfProperties>) => {
+      const req = new Request(input, init)
+      const useEnv = req.url.includes("/mpu/complete") ? tightEnv : env
+      return await worker.fetch(req, useEnv, ctx)
+    })
+
+    const big = genRandomBlob(1024 * 1024 * 5)
+    await expect(
+      uploadMPU(BASE_URL, 1024 * 1024 * 5, {
+        isUpdate: false,
+        content: new File([await big.arrayBuffer()], "big.bin"),
+      }),
+    ).rejects.toMatchObject({ statusCode: 413 })
+  })
+})

--- a/worker/test/storage.spec.ts
+++ b/worker/test/storage.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createExecutionContext, createScheduledController, env, waitOnExecutionContext } from "cloudflare:test"
+import { addRole, BASE_URL, genRandomBlob, upload, workerFetch } from "./testUtils.js"
+import worker from "../index.js"
+import { parseSize } from "../../shared/parsers.js"
+import type { PasteMetadata } from "../storage/storage.js"
+
+beforeEach(vi.useFakeTimers)
+afterEach(vi.useRealTimers)
+
+describe("getPaste / getPasteMetadata expiration", () => {
+  it("returns 404 once a paste has expired and removes it from KV", async () => {
+    const ctx = createExecutionContext()
+
+    vi.setSystemTime(new Date(2030, 0, 1))
+    const seeded = await upload(ctx, { c: new Blob(["hello"]), e: "70" })
+    const url = seeded.url
+    const name = url.slice(BASE_URL.length + 1)
+
+    // sanity: still alive right after upload
+    expect((await workerFetch(ctx, url)).status).toStrictEqual(200)
+
+    // jump past the paste's expiration; getPaste should now report 404 and schedule deletion
+    vi.setSystemTime(new Date(2030, 0, 2))
+    const stale = await workerFetch(ctx, url)
+    expect(stale.status).toStrictEqual(404)
+    await waitOnExecutionContext(ctx)
+
+    // the underlying KV record should be gone
+    const raw = await env.PB.getWithMetadata<PasteMetadata>(name)
+    expect(raw.value).toBeNull()
+
+    // the meta endpoint should also return 404 (covers getPasteMetadata's expired branch)
+    expect((await workerFetch(ctx, addRole(url, "m"))).status).toStrictEqual(404)
+  })
+})
+
+describe("pasteNameAvailable", () => {
+  it("treats expired pastes as available so the same name can be reused", async () => {
+    const ctx = createExecutionContext()
+
+    vi.setSystemTime(new Date(2031, 0, 1))
+    const customName = "reusable"
+    await upload(ctx, { c: new Blob(["first"]), n: customName, e: "70" })
+
+    // re-uploading immediately should conflict
+    const conflictResp = await workerFetch(
+      ctx,
+      new Request(BASE_URL, {
+        method: "POST",
+        body: (() => {
+          const fd = new FormData()
+          fd.set("c", new Blob(["second"]))
+          fd.set("n", customName)
+          return fd
+        })(),
+      }),
+    )
+    expect(conflictResp.status).toStrictEqual(409)
+
+    // after the original has expired, the same name should become available again
+    vi.setSystemTime(new Date(2031, 0, 5))
+    const reuseResp = await upload(ctx, { c: new Blob(["second"]), n: customName, e: "70" })
+    expect(reuseResp.url.endsWith("/~" + customName)).toStrictEqual(true)
+  })
+})
+
+describe("cleanExpiredInR2", () => {
+  it("cleans up R2 objects without custom expiration metadata when their KV record is gone", async () => {
+    const ctx = createExecutionContext()
+
+    // write an R2 object directly with no customMetadata. This mimics legacy or in-flight MPU
+    // objects whose expiration must be looked up from KV (the needKvLookup branch).
+    const orphanKey = "~orphan_r2_object"
+    await env.R2.put(orphanKey, "stale data")
+    expect(await env.R2.head(orphanKey)).not.toBeNull()
+
+    // also seed an R2-backed paste through the normal pipeline so we exercise the
+    // customMetadata.willExpireAtUnix branch with an expired entry.
+    vi.setSystemTime(new Date(2032, 0, 1))
+    const big = genRandomBlob(parseSize(env.R2_THRESHOLD)! * 2)
+    const seeded = await upload(ctx, { c: big, e: "70" })
+    const seededName = seeded.url.slice(BASE_URL.length + 1)
+    expect(await env.R2.head(seededName)).not.toBeNull()
+
+    // jump far into the future and run the scheduled cleanup
+    await worker.scheduled(createScheduledController({ scheduledTime: new Date(2040, 0, 0) }), env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(await env.R2.head(orphanKey)).toBeNull()
+    expect(await env.R2.head(seededName)).toBeNull()
+  })
+})

--- a/worker/test/writeErrors.spec.ts
+++ b/worker/test/writeErrors.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest"
+import { createExecutionContext, env } from "cloudflare:test"
+import { BASE_URL, upload, uploadExpectStatus, workerFetch } from "./testUtils.js"
+import worker from "../index.js"
+
+const ctx = createExecutionContext()
+
+describe("write error paths — content/format validation", () => {
+  it("POST without `c` field returns 400", async () => {
+    await uploadExpectStatus(ctx, { e: "1d" }, 400)
+  })
+
+  it("POST with non-multipart Content-Type returns 400", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: '{"c":"x"}',
+      }),
+    )
+    expect(resp.status).toStrictEqual(400)
+    expect(await resp.text()).toContain("multipart/form-data")
+  })
+
+  it("POST with malformed multipart body returns 400", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "multipart/form-data; boundary=----xyz" },
+        body: "this is not valid multipart\r\n",
+      }),
+    )
+    expect(resp.status).toStrictEqual(400)
+  })
+
+  it("POST exceeding R2_MAX_ALLOWED returns 413", async () => {
+    const tightEnv = { ...env, R2_MAX_ALLOWED: "10" }
+    const fd = new FormData()
+    fd.set("c", new Blob(["this payload is definitely longer than 10 bytes"]))
+    const resp = await worker.fetch(new Request(BASE_URL, { method: "POST", body: fd }), tightEnv, ctx)
+    expect(resp.status).toStrictEqual(413)
+  })
+
+  it("POST/PUT to an unknown /mpu/* path returns 400", async () => {
+    const fd = new FormData()
+    fd.set("c", new Blob(["x"]))
+
+    const resp = await workerFetch(ctx, new Request(`${BASE_URL}/mpu/bogus`, { method: "POST", body: fd }))
+    expect(resp.status).toStrictEqual(400)
+    expect(await resp.text()).toContain("illegal mpu operation")
+  })
+})
+
+describe("write error paths — name and password validation", () => {
+  it("POST with name not matching NAME_REGEX returns 400", async () => {
+    await uploadExpectStatus(ctx, { c: new Blob(["x"]), n: "ab!cd" }, 400)
+  })
+
+  it("POST with already-used name returns 409", async () => {
+    const name = "takenname"
+    await upload(ctx, { c: new Blob(["first"]), n: name })
+    await uploadExpectStatus(ctx, { c: new Blob(["second"]), n: name }, 409)
+  })
+
+  it("POST with too-short password returns 400", async () => {
+    await uploadExpectStatus(ctx, { c: new Blob(["x"]), s: "short" }, 400)
+  })
+
+  it("POST with too-long password returns 400", async () => {
+    await uploadExpectStatus(ctx, { c: new Blob(["x"]), s: "a".repeat(129) }, 400)
+  })
+
+  it("POST with newline in password returns 400", async () => {
+    await uploadExpectStatus(ctx, { c: new Blob(["x"]), s: "abc12345\nabcdef" }, 400)
+  })
+
+  it("POST with invalid expire format returns 400", async () => {
+    await uploadExpectStatus(ctx, { c: new Blob(["x"]), e: "weird-format" }, 400)
+  })
+})
+
+describe("write error paths — PUT specifics", () => {
+  it("PUT with `n` field returns 400 (cannot rename)", async () => {
+    const seeded = await upload(ctx, { c: new Blob(["x"]) })
+    await uploadExpectStatus(ctx, { c: new Blob(["y"]), n: "newname" }, 400, {
+      method: "PUT",
+      url: seeded.manageUrl,
+    })
+  })
+
+  it("PUT without password in URL returns 403", async () => {
+    const seeded = await upload(ctx, { c: new Blob(["x"]) })
+    await uploadExpectStatus(ctx, { c: new Blob(["y"]) }, 403, {
+      method: "PUT",
+      url: seeded.url, // url has no `:password` suffix
+    })
+  })
+
+  it("PUT to a non-existent paste returns 404", async () => {
+    await uploadExpectStatus(ctx, { c: new Blob(["x"]) }, 404, {
+      method: "PUT",
+      url: `${BASE_URL}/zzzzz:somepasswd`,
+    })
+  })
+})
+
+describe("write error paths — MPU complete name validation", () => {
+  function completeFormData(): FormData {
+    const fd = new FormData()
+    fd.set("c", new File([JSON.stringify([])], "parts.json"))
+    return fd
+  }
+
+  it("POST /mpu/complete without name returns 400", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/complete?key=k&uploadId=u`, {
+        method: "POST",
+        body: completeFormData(),
+      }),
+    )
+    expect(resp.status).toStrictEqual(400)
+    expect(await resp.text()).toContain("no name for MPU complete")
+  })
+
+  it("PUT /mpu/complete without name returns 400", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/complete?key=k&uploadId=u`, {
+        method: "PUT",
+        body: completeFormData(),
+      }),
+    )
+    expect(resp.status).toStrictEqual(400)
+    expect(await resp.text()).toContain("no name for MPU complete")
+  })
+})


### PR DESCRIPTION
- **fix(parsers): tighten size/expiration regex to reject multiple dots**
- **fix(mpu): check name conflict against the ~-prefixed key**
- **fix(write): await MPU sub-handlers so rejections stay in the try/catch**
- **test: add Shared vitest project; exclude test dirs from coverage**
- **test: extend tier 1 coverage and add negative-path tests**
