### PR TITLE
feat(frontend): drag files onto Edit tab + clearer file selection text

### DIFF
--- a/frontend/components/PasteInputPanel.tsx
+++ b/frontend/components/PasteInputPanel.tsx
@@ -26,6 +26,7 @@ interface PasteEditorProps extends CardProps {
 export function PasteInputPanel({ isPasteLoading, state, onStateChange, ...rest }: PasteEditorProps) {
   const fileInput = useRef<HTMLInputElement>(null)
   const [isDragged, setDragged] = useState<boolean>(false)
+  const [isEditDragged, setEditDragged] = useState<boolean>(false)
 
   function setFile(file: File | null) {
     onStateChange({ ...state, editKind: "file", file })
@@ -44,6 +45,7 @@ export function PasteInputPanel({ isPasteLoading, state, onStateChange, ...rest 
       }
     }
     setDragged(false)
+    setEditDragged(false)
   }
 
   return (
@@ -64,16 +66,46 @@ export function PasteInputPanel({ isPasteLoading, state, onStateChange, ...rest 
         >
           {/*Possibly a bug of chrome, but Tab sometimes has a transient unexpected scrollbar when resizing*/}
           <Tab key={"edit"} title="Edit" className={"overflow-hidden"}>
-            <CodeEditor
-              content={state.editContent}
-              setContent={(k) => onStateChange({ ...state, editContent: k })}
-              lang={state.editHighlightLang}
-              setLang={(lang) => onStateChange({ ...state, editHighlightLang: lang })}
-              filename={state.editFilename}
-              setFilename={(name) => onStateChange({ ...state, editFilename: name })}
-              disabled={isPasteLoading}
-              placeholder={isPasteLoading ? "Loading..." : "Edit your paste here"}
-            />
+            <div
+              className="relative"
+              onDrop={onDrop}
+              onDragEnter={(e) => {
+                e.preventDefault()
+                setEditDragged(true)
+              }}
+              onDragOver={(e) => {
+                e.preventDefault()
+                setEditDragged(true)
+              }}
+              onDragLeave={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                  setEditDragged(false)
+                }
+              }}
+            >
+              <CodeEditor
+                content={state.editContent}
+                setContent={(k) => onStateChange({ ...state, editContent: k })}
+                lang={state.editHighlightLang}
+                setLang={(lang) => onStateChange({ ...state, editHighlightLang: lang })}
+                filename={state.editFilename}
+                setFilename={(name) => onStateChange({ ...state, editFilename: name })}
+                disabled={isPasteLoading}
+                placeholder={isPasteLoading ? "Loading..." : "Edit your paste here"}
+              />
+              {isEditDragged && (
+                <div
+                  className={
+                    `absolute inset-0 rounded-xl flex flex-col items-center justify-center ` +
+                    `bg-primary-100 pointer-events-none ${tst}`
+                  }
+                  aria-hidden="true"
+                >
+                  <div className="text-2xl my-2 font-bold">Drop file here</div>
+                  <p className="text-1xl text-foreground-500">Release to upload as file</p>
+                </div>
+              )}
+            </div>
           </Tab>
           <Tab key="file" title="File">
             <div
@@ -103,11 +135,13 @@ export function PasteInputPanel({ isPasteLoading, state, onStateChange, ...rest 
                   }
                 }}
               />
-              <div className="text-2xl my-2 font-bold">Select File</div>
+              <div className="text-2xl my-2 font-bold px-4 text-center break-all">
+                {state.file !== null ? state.file.name : "Select File"}
+              </div>
               <p className={`text-1xl text-foreground-500 ${tst} relative`}>
                 <span>
                   {state.file !== null
-                    ? `${state.file.name} (${formatSize(state.file.size)})`
+                    ? `${formatSize(state.file.size)} · Click or drag to replace`
                     : "Click or drag & drop file here"}
                 </span>
               </p>


### PR DESCRIPTION
Edit tab area (filename row + code editor) now accepts file drops with the
same primary-100 overlay treatment as the File tab; dropping switches to
the File tab automatically. Also swaps the File tab text hierarchy after
selection so the filename is the headline and the size/replace hint sits
below, instead of leaving "Select File" prominent when a file is already
chosen.

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
