### PR TITLE
Markdown rendering and Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pastebin-worker
 
-This is a pastebin that can be deployed on Cloudflare workers. Try it on [shz.al](https://shz.al).
+This is a pastebin running on Cloudflare workers. Try it on [shz.al](https://shz.al).
 
 **Philosophy**: effortless deployment, friendly CLI usage, rich functionality.
 
@@ -8,10 +8,10 @@ This is a pastebin that can be deployed on Cloudflare workers. Try it on [shz.al
 
 1. Share your paste with as short as 4 characters, or even customized URL.
 1. **Syntax highlighting** powered by highlight.js.
-1. Client-side encryption
-1. Render **markdown** file as HTML
-1. URL shortener
-1. Customize returned `Content-Type`
+1. Client-side encryption.
+1. Render **markdown** file as HTML.
+1. URL shortener.
+1. Smart and tweakable handling for `Content-Type` and `Content-Disposition`.
 
 ## Usage
 
@@ -23,9 +23,21 @@ This is a pastebin that can be deployed on Cloudflare workers. Try it on [shz.al
 
 4. [doc/skill.md](doc/skill.md) is a concise, AI-agent-oriented packaging of the API. Make it available to your coding agent so it can upload, fetch, and manage pastes via this service.
 
-## Limitations
+## Cost
 
-1. If deployed on Cloudflare Worker free-tier plan, the service allows at most 100,000 reads and 1000 writes, 1000 deletes per day.
+The service runs on Cloudflare Workers, Workers KV, and R2. Each has a free tier; beyond it you pay only for what you use. Figures below are accurate as of writing — **prices change, so confirm against the official pricing pages before relying on them**:
+
+- **[Workers](https://developers.cloudflare.com/workers/platform/pricing/)** — Free plan: 100,000 requests/day, 10 ms CPU per invocation. Paid plan: $5/mo base, includes 10 M requests/month + 30 M ms CPU/month, then $0.30 per additional million requests and $0.02 per additional million CPU-ms. Egress is free. The $5/mo Paid plan also unlocks the higher KV limits below (KV does not have a separate paid plan).
+- **[Workers KV](https://developers.cloudflare.com/kv/platform/pricing/)** (small pastes and per-paste metadata) — Free plan (daily, resets 00:00 UTC): 100 k reads, 1 k writes, 1 k deletes, 1 k list ops, 1 GB storage. Paid plan (monthly + overage): 10 M reads ($0.50/M extra), 1 M writes ($5/M), 1 M deletes ($5/M), 1 M list ops ($5/M), 1 GB storage ($0.50/GB-month extra).
+- **[R2](https://developers.cloudflare.com/r2/pricing/)** (paste content above `R2_THRESHOLD`) — Free: 10 GB-month storage, 1 M Class A ops/month, 10 M Class B ops/month, **egress free**. Standard paid: $0.015/GB-month storage, $4.50 per million Class A ops (writes/lists), $0.36 per million Class B ops (reads). Class A op = upload (`PutObject`); Class B op = fetch (`GetObject`). Cloudflare rounds storage up to the next GB-month.
+- **[Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/)** (optional, off unless enabled in `wrangler.toml`) — Free: 200 k events/day, 3-day retention. Paid: 20 M events/month included + $0.60 per additional million, 7-day retention.
+
+For a personal deployment the free tier is typically sufficient. Costs scale primarily with: large file traffic (R2 ops + storage), high-volume reads (Workers requests + KV reads), and verbose logging (Workers Logs events).
+
+**Bottom line — what each tier comfortably handles**:
+
+- **Free tier**: a personal pastebin. The binding limits are KV writes (**1,000 uploads/day**) and KV/Workers reads (**~100,000 fetches/day**), with **1 GB** of small-paste storage and **10 GB** of large-paste storage on R2. Plenty for individual or small-team use.
+- **$5/month Paid**: a small public or community service. Roughly **~33,000 uploads/day** and **~333,000 fetches/day** stay within the included monthly KV allotment; Workers requests included to ~10 M/month (~333 k/day). R2 storage and ops come out of R2's separate free tier first, then a few cents per GB-month and per million ops — adding only a few dollars even at moderate traffic.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a pastebin that can be deployed on Cloudflare workers. Try it on [shz.al
 
 3. [pb](/scripts) is a bash script to make it easier to use on command line.
 
-4. [SKILL.md](SKILL.md) is a concise, AI-agent-oriented packaging of the API. Make it available to your coding agent so it can upload, fetch, and manage pastes via this service.
+4. [doc/skill.md](doc/skill.md) is a concise, AI-agent-oriented packaging of the API. Make it available to your coding agent so it can upload, fetch, and manage pastes via this service.
 
 ## Limitations
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,7 @@
 # Pastebin Worker
 
-A self-hosted pastebin running on Cloudflare Workers. Visit {{BASE_URL}} in a
-browser for the full UI, or use `curl` from the terminal.
+A pastebin running on Cloudflare Workers. Visit {{BASE_URL}} in a browser for the full UI, or use
+`curl` from the terminal.
 
 ## Quick start
 
@@ -17,9 +17,10 @@ deletion.
 ## More
 
 ```shell
-$ curl {{BASE_URL}}/doc/curl       # comprehensive curl usage
-$ curl {{BASE_URL}}/doc/api        # HTTP API reference
-$ curl {{BASE_URL}}/doc/tos        # terms of service
+$ curl {{BASE_URL}}/doc/curl.md    # comprehensive curl usage
+$ curl {{BASE_URL}}/doc/api.md     # HTTP API reference
+$ curl {{BASE_URL}}/doc/skill.md   # AI agent skill (concise, ready to feed into a coding agent)
+$ curl {{BASE_URL}}/doc/tos.md     # terms of service
 ```
 
 Source: {{REPO}}

--- a/doc/skill.md
+++ b/doc/skill.md
@@ -1,28 +1,28 @@
 ---
 name: shz-al
-description: Upload, fetch, update, or delete text/binary content via shz.al, a curl-friendly pastebin. Use when you need a quick public URL for sharing long output, hosting a small file, shortening a URL, or rendering markdown as HTML.
+description: Upload, fetch, update, or delete text/binary content via {{BASE_URL}}, a curl-friendly pastebin. Use when you need a quick public URL for sharing long output, hosting a small file, shortening a URL, or rendering markdown as HTML.
 ---
 
 # shz.al
 
-A pastebin hosted on Cloudflare Workers at `https://shz.al`. Every operation is
+A pastebin hosted on Cloudflare Workers at `{{BASE_URL}}`. Every operation is
 plain HTTP and works with `curl`. Random paste names appear bare (e.g. `abcd`);
 custom names are returned with a leading `~` (e.g. `~hitagi`).
 
 ## Upload
 
 ```shell
-curl -Fc='hello, world' https://shz.al        # text
-curl -Fc=@file.png      https://shz.al        # file
-<cmd> | curl -Fc=@-     https://shz.al        # stdin
+curl -Fc='hello, world' {{BASE_URL}}        # text
+curl -Fc=@file.png      {{BASE_URL}}        # file
+<cmd> | curl -Fc=@-     {{BASE_URL}}        # stdin
 ```
 
 Response:
 
 ```json
 {
-  "url": "https://shz.al/abcd",
-  "manageUrl": "https://shz.al/abcd:<password>",
+  "url": "{{BASE_URL}}/abcd",
+  "manageUrl": "{{BASE_URL}}/abcd:<password>",
   "expireAt": "2026-05-21T10:33:06.114Z"
 }
 ```
@@ -42,10 +42,10 @@ is the only way to authenticate as the owner.
 ## Fetch
 
 ```shell
-curl https://shz.al/<name>                    # raw content
-curl -OJ https://shz.al/~<name>               # save with server filename
-curl https://shz.al/m/<name>                  # JSON metadata (size, dates, …)
-curl -I https://shz.al/<name>                 # HEAD only
+curl {{BASE_URL}}/<name>                    # raw content
+curl -OJ {{BASE_URL}}/~<name>               # save with server filename
+curl {{BASE_URL}}/m/<name>                  # JSON metadata (size, dates, …)
+curl -I {{BASE_URL}}/<name>                 # HEAD only
 ```
 
 Append `?a` for `Content-Disposition: attachment`, `?mime=<mime>` to override
@@ -67,7 +67,13 @@ curl -X DELETE                   <manageUrl>
 - `/a/<name>` — render the paste as HTML (GitHub-flavored Markdown + MathJax).
 - `/u/<name>` — redirect to the URL stored in the paste (URL shortener).
 
+## Limitations
+
+- Default expiration is `{{DEFAULT_EXPIRATION}}`, max `{{MAX_EXPIRATION}}`. Pastes are deleted on expiry.
+- Max upload size is `{{R2_MAX_ALLOWED}}`.
+- Treat the service as ephemeral storage — do not rely on it for archival.
+
 ## Full docs
 
-- `https://shz.al/doc/curl.md` — comprehensive curl guide.
-- `https://shz.al/doc/api.md` — HTTP API reference.
+- `{{BASE_URL}}/doc/curl.md` — comprehensive curl guide.
+- `{{BASE_URL}}/doc/api.md` — HTTP API reference.

--- a/frontend/pages/PasteBin.tsx
+++ b/frontend/pages/PasteBin.tsx
@@ -187,15 +187,19 @@ export function PasteBin({ config }: { config: Env }) {
         <h1 className="text-3xl">{config.INDEX_PAGE_TITLE}</h1>
         <DarkModeToggle modeSelection={modeSelection} setModeSelection={setModeSelection} />
       </div>
-      <p className="my-2">An open source pastebin deployed on Cloudflare Workers. </p>
+      <p className="my-2">A pastebin running on Cloudflare Workers.</p>
       <p className="my-2">
         <b>Usage</b>: paste text or drop a file, then share the returned URL. You can also use{" "}
         <Link className={tst} href={`${config.DEPLOY_URL}/doc/curl`}>
           curl
         </Link>
-        {" or the "}
+        {", the "}
         <Link className={tst} href={`${config.DEPLOY_URL}/doc/api`}>
           HTTP API
+        </Link>
+        {", or as an "}
+        <Link className={tst} href={`${config.DEPLOY_URL}/doc/skill.md`}>
+          AI agent skill
         </Link>
         .
       </p>

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "bcrypt-ts": "^8.0.1",
     "chardet": "^2.1.1",
     "framer-motion": "^12.38.0",
+    "github-slugger": "^2.0.0",
     "highlight.js": "^11.11.1",
     "mdast-util-to-string": "^4.0.0",
     "mime": "^4.1.0",
@@ -72,7 +73,8 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "tailwindcss": "^4.2.4",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   },
   "resolutions": {
     "stringify-entities": "4.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -68,6 +71,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.2
@@ -1649,6 +1655,9 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -4029,6 +4038,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  github-slugger@2.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:

--- a/worker/pages/docs.ts
+++ b/worker/pages/docs.ts
@@ -3,6 +3,7 @@ import { makeMarkdown } from "./markdown.js"
 import tosMd from "../../doc/tos.md"
 import apiMd from "../../doc/api.md"
 import curlMd from "../../doc/curl.md"
+import skillMd from "../../doc/skill.md"
 import indexMd from "../../doc/index.md"
 
 function renderTemplate(template: string, env: Env): string {
@@ -11,6 +12,9 @@ function renderTemplate(template: string, env: Env): string {
     .replaceAll("{{REPO}}", env.REPO)
     .replaceAll("{{TOS_MAINTAINER}}", env.TOS_MAINTAINER)
     .replaceAll("{{TOS_MAIL}}", env.TOS_MAIL)
+    .replaceAll("{{DEFAULT_EXPIRATION}}", env.DEFAULT_EXPIRATION)
+    .replaceAll("{{MAX_EXPIRATION}}", env.MAX_EXPIRATION)
+    .replaceAll("{{R2_MAX_ALLOWED}}", env.R2_MAX_ALLOWED)
 }
 
 export function getDocMarkdown(path: string, env: Env): string | null {
@@ -20,6 +24,8 @@ export function getDocMarkdown(path: string, env: Env): string | null {
     return renderTemplate(apiMd, env)
   } else if (path === "/doc/curl" || path === "/doc/curl.html") {
     return renderTemplate(curlMd, env)
+  } else if (path === "/doc/skill" || path === "/doc/skill.html") {
+    return renderTemplate(skillMd, env)
   } else {
     return null
   }
@@ -30,5 +36,5 @@ export function getCurlIndexMarkdown(env: Env): string {
 }
 
 export function renderDocAsHtml(md: string): string {
-  return makeMarkdown(md)
+  return makeMarkdown(md.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, ""))
 }

--- a/worker/pages/markdown.ts
+++ b/worker/pages/markdown.ts
@@ -1,53 +1,186 @@
 import { unified } from "unified"
-import type { Root } from "mdast"
+import type { Root, Heading } from "mdast"
 import remarkParse from "remark-parse"
 import remarkGfm from "remark-gfm"
 import remarkRehype from "remark-rehype"
 import rehypeStringify from "rehype-stringify"
 import { toString } from "mdast-util-to-string"
+import { visit } from "unist-util-visit"
+import GithubSlugger from "github-slugger"
 
 import { escapeHtml } from "../common.js"
 
 const descriptionLimit = 200
 const defaultTitle = "Untitled"
+const TOC_MIN_DEPTH = 2
+const TOC_MAX_DEPTH = 4
+const TOC_THRESHOLD = 3
+
+interface TocEntry {
+  depth: number
+  text: string
+  id: string
+}
 
 interface DocMetadata {
   title: string
   description: string
+  toc: TocEntry[]
 }
 
-function getMetadata(options: { result: DocMetadata }): (_: Root) => void {
+function collectMetadata(options: { result: DocMetadata }): (_: Root) => void {
   return (tree: Root) => {
-    if (tree.children.length === 0) return
-
-    const firstChild = tree.children[0]
-    // if the document begins with a h1, set its content as the title
-    if (firstChild.type === "heading" && firstChild.depth === 1) {
-      options.result.title = escapeHtml(toString(firstChild))
-
-      if (tree.children.length > 1) {
-        // description is set as the content of the second node
-        const secondChild = tree.children[1]
-        options.result.description = escapeHtml(toString(secondChild).slice(0, descriptionLimit))
+    if (tree.children.length > 0) {
+      const firstChild = tree.children[0]
+      if (firstChild.type === "heading" && firstChild.depth === 1) {
+        options.result.title = escapeHtml(toString(firstChild))
+        if (tree.children.length > 1) {
+          const secondChild = tree.children[1]
+          options.result.description = escapeHtml(toString(secondChild).slice(0, descriptionLimit))
+        }
+      } else {
+        options.result.description = escapeHtml(toString(firstChild).slice(0, descriptionLimit))
       }
-    } else {
-      // no title is set
-      // description is set as the content of the first node
-      options.result.description = escapeHtml(toString(firstChild).slice(0, descriptionLimit))
     }
+
+    const slugger = new GithubSlugger()
+    visit(tree, "heading", (node: Heading) => {
+      const text = toString(node)
+      const id = slugger.slug(text)
+
+      node.data ??= {}
+      const data = node.data as { hProperties?: Record<string, unknown> }
+      data.hProperties ??= {}
+      data.hProperties.id = id
+
+      options.result.toc.push({ depth: node.depth, text, id })
+
+      node.children.unshift({
+        type: "link",
+        url: `#${id}`,
+        data: {
+          hProperties: { class: "header-anchor", "aria-label": `Permalink to ${text}` },
+        },
+        children: [{ type: "text", value: "#" }],
+      })
+    })
   }
 }
 
+function renderToc(toc: TocEntry[]): string {
+  const filtered = toc.filter((h) => h.depth >= TOC_MIN_DEPTH && h.depth <= TOC_MAX_DEPTH)
+  if (filtered.length < TOC_THRESHOLD) return ""
+
+  const openDepths: number[] = []
+  let html = ""
+
+  for (const entry of filtered) {
+    while (openDepths.length > 0 && openDepths[openDepths.length - 1] > entry.depth) {
+      html += "</li></ol>"
+      openDepths.pop()
+    }
+    const top = openDepths[openDepths.length - 1]
+    if (top === entry.depth) {
+      html += "</li>"
+    } else {
+      html += "<ol>"
+      openDepths.push(entry.depth)
+    }
+    html += `<li><a href="#${entry.id}">${escapeHtml(entry.text)}</a>`
+  }
+  while (openDepths.length > 0) {
+    html += "</li></ol>"
+    openDepths.pop()
+  }
+
+  return `<nav class="toc" aria-label="Table of contents">${html}</nav>`
+}
+
+const sidebarStyles = `
+  body { margin: 0; }
+  .page { display: grid; grid-template-columns: minmax(0, 1fr); gap: 2rem; max-width: 1200px; margin: 2rem auto; padding: 0 1rem; box-sizing: border-box; }
+  .page > article { min-width: 0; }
+  @media (min-width: 1024px) { .page.has-toc { grid-template-columns: 240px minmax(0, 1fr); } }
+  .toc { font-size: 0.9em; line-height: 1.5; }
+  @media (min-width: 1024px) { .toc { position: sticky; top: 1rem; align-self: start; max-height: calc(100vh - 2rem); overflow-y: auto; } }
+  .toc ol { list-style: none; padding-left: 1em; margin: 0; }
+  .toc > ol { padding-left: 0; }
+  .toc li { margin: 0; }
+  .toc a { display: block; padding: 0.2rem 0 0.2rem 0.5rem; color: #57606a; text-decoration: none; border-left: 2px solid transparent; }
+  .toc a:hover { color: #0969da; }
+  .toc a.active { color: #0969da; border-left-color: #0969da; background: rgba(9, 105, 218, 0.06); }
+  .markdown-body :is(h1, h2, h3, h4, h5, h6) .header-anchor { opacity: 0; margin-left: -0.8em; padding-right: 0.2em; color: #57606a; text-decoration: none; font-weight: normal; }
+  .markdown-body :is(h1, h2, h3, h4, h5, h6):hover .header-anchor,
+  .markdown-body .header-anchor:focus { opacity: 1; }
+`
+
+const scrollSpyScript = `
+(() => {
+  const links = new Map();
+  document.querySelectorAll('.toc a[href^="#"]').forEach((a) => {
+    links.set(decodeURIComponent(a.getAttribute('href').slice(1)), a);
+  });
+  if (!links.size) return;
+  const headings = [];
+  links.forEach((_, id) => {
+    const el = document.getElementById(id);
+    if (el) headings.push(el);
+  });
+  if (!headings.length) return;
+  let active = null;
+  let lockUntil = 0;
+  const setActive = (link) => {
+    if (link === active) return;
+    if (active) active.classList.remove('active');
+    if (link) link.classList.add('active');
+    active = link;
+  };
+  const update = () => {
+    if (Date.now() < lockUntil) return;
+    const threshold = 80;
+    let current = null;
+    for (const h of headings) {
+      if (h.getBoundingClientRect().top <= threshold) current = h;
+      else break;
+    }
+    if (!current) current = headings[0];
+    setActive(links.get(current.id));
+  };
+  const setActiveByHash = () => {
+    if (!location.hash) return false;
+    const id = decodeURIComponent(location.hash.slice(1));
+    const link = links.get(id);
+    if (!link) return false;
+    setActive(link);
+    lockUntil = Date.now() + 800;
+    return true;
+  };
+  let ticking = false;
+  const onScroll = () => {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(() => { ticking = false; update(); });
+  };
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll, { passive: true });
+  window.addEventListener('hashchange', setActiveByHash);
+  if (!setActiveByHash()) update();
+})();
+`
+
 export function makeMarkdown(content: string): string {
-  const metadata: DocMetadata = { title: defaultTitle, description: "" }
+  const metadata: DocMetadata = { title: defaultTitle, description: "", toc: [] }
   const convertedHtml = unified()
     .use(remarkParse)
     .use(remarkGfm)
-    .use(getMetadata, { result: metadata }) // result is written to `metadata` variable
+    .use(collectMetadata, { result: metadata })
     .use(remarkRehype)
     .use(rehypeStringify)
     .processSync(content)
     .value.toString()
+
+  const tocHtml = renderToc(metadata.toc)
+  const hasToc = tocHtml.length > 0
 
   return `<!DOCTYPE html>
 <html lang='en'>
@@ -59,17 +192,22 @@ export function makeMarkdown(content: string): string {
   <link href='https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism.css' rel='stylesheet' />
   <link href='https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/line-numbers/prism-line-numbers.css' rel='stylesheet' />
   <link rel='stylesheet' href='https://pages.github.com/assets/css/style.css'>
+  <style>${sidebarStyles}</style>
   <script id="MathJax-script" async
           src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
   </script>
 </head>
 <body>
-<article class='line-numbers container-lg px-3 my-5 markdown-body'>
+<div class='page${hasToc ? " has-toc" : ""}'>
+${tocHtml}
+<article class='line-numbers px-3 markdown-body'>
 ${convertedHtml}
 </article>
+</div>
   <script src='https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js'></script>
   <script src='https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/line-numbers/prism-line-numbers.min.js'></script>
   <script src='https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/autoloader/prism-autoloader.min.js'></script>
+  ${hasToc ? `<script>${scrollSpyScript}</script>` : ""}
 </html>
 `
 }

--- a/worker/test/docPages.spec.ts
+++ b/worker/test/docPages.spec.ts
@@ -12,7 +12,7 @@ describe("doc pages", () => {
   const ctx = createExecutionContext()
 
   it("returns rendered HTML to browsers", async () => {
-    for (const page of ["/doc/api", "/doc/tos", "/doc/curl"]) {
+    for (const page of ["/doc/api", "/doc/tos", "/doc/curl", "/doc/skill"]) {
       const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: browserHeaders }))
       expect(resp.status, `visiting ${page}`).toStrictEqual(200)
       expect(resp.headers.get("Content-Type")).toStrictEqual("text/html;charset=UTF-8")
@@ -22,7 +22,7 @@ describe("doc pages", () => {
   })
 
   it("returns raw markdown to curl", async () => {
-    for (const page of ["/doc/api", "/doc/tos", "/doc/curl"]) {
+    for (const page of ["/doc/api", "/doc/tos", "/doc/curl", "/doc/skill"]) {
       const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: curlHeaders }))
       expect(resp.status, `visiting ${page}`).toStrictEqual(200)
       expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
@@ -41,7 +41,7 @@ describe("doc pages", () => {
   })
 
   it("serves markdown to any UA on /doc/<name>.md", async () => {
-    for (const page of ["/doc/api.md", "/doc/tos.md", "/doc/curl.md"]) {
+    for (const page of ["/doc/api.md", "/doc/tos.md", "/doc/curl.md", "/doc/skill.md"]) {
       const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: browserHeaders }))
       expect(resp.status, `visiting ${page}`).toStrictEqual(200)
       expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")

--- a/worker/test/testUtils.ts
+++ b/worker/test/testUtils.ts
@@ -23,6 +23,9 @@ export const staticPages = [
   "doc/curl",
   "doc/curl.html",
   "doc/curl.md",
+  "doc/skill",
+  "doc/skill.html",
+  "doc/skill.md",
   "favicon.ico",
 ]
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -65,17 +65,17 @@ CACHE_PASTE_AGE = 600
 DEFAULT_EXPIRATION = "7d"
 
 # Max expiration
-MAX_EXPIRATION = "30d"
+MAX_EXPIRATION = "90d"
 
 # A collection of {username: password} pair
 # Leave empty to disable auth
 BASIC_AUTH = {}
 
 # Files larger than this threshold will be stored in R2
-R2_THRESHOLD = "100K"
+R2_THRESHOLD = "20K"
 
 # File larger than this will be denied
-R2_MAX_ALLOWED = "100M"
+R2_MAX_ALLOWED = "256M"
 
 # The following mimetypes will be converted to text/plain
 DISALLOWED_MIME_FOR_PASTE = ["text/html", "audio/x-mpegurl"]


### PR DESCRIPTION
- **feat(worker): add ToC sidebar, heading anchors, scroll-spy to markdown render**
- **chore: bump deployment limits in wrangler.toml**
- **feat: move SKILL.md to doc/, expose at /doc/skill, link from index**
- **docs(README): rewrite Limitations as detailed Cost breakdown**
