### PR TITLE
Improve MPU frontend/backend handling, rewrite pb script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage
 .dev.vars*
 .pnp.*
 .yarn
+__pycache__

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a pastebin running on Cloudflare workers. Try it on [shz.al](https://shz
 
 2. It also provides a convenient HTTP API to use. See [API reference](doc/api.md) for details. You can easily call API via command line (using `curl` or similar tools).
 
-3. [pb](/scripts) is a bash script to make it easier to use on command line.
+3. [pb](/scripts) is a Python script (requires Python 3.9+ with the `requests` package) to make it easier to use on command line.
 
 4. [doc/skill.md](doc/skill.md) is a concise, AI-agent-oriented packaging of the API. Make it available to your coding agent so it can upload, fetch, and manage pastes via this service.
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This is a pastebin running on Cloudflare workers. Try it on [shz.al](https://shz
 
 1. You can post, update, delete your paste directly on the website (such as [shz.al](https://shz.al)).
 
-2. It also provides a convenient HTTP API to use. See [API reference](doc/api.md) for details. You can easily call API via command line (using `curl` or similar tools).
+2. It also provides a convenient HTTP API to use. See [API reference](doc/api.md) for details. You can easily call API via command line (using `curl` or similar tools). Note that a single request body is capped at 100 MB by Cloudflare (the platform returns HTTP `413` for larger bodies before the worker runs) — for larger files, use the website or the `pb` CLI below, which transparently chunk the upload.
 
-3. [pb](/scripts) is a Python script (requires Python 3.9+ with the `requests` package) to make it easier to use on command line.
+3. [pb](/scripts) is a Python script (requires Python 3.9+ with the `requests` package) to make it easier to use on command line; it automatically switches to multipart upload above 5 MiB and shows a progress bar.
 
 4. [doc/skill.md](doc/skill.md) is a concise, AI-agent-oriented packaging of the API. Make it available to your coding agent so it can upload, fetch, and manage pastes via this service.
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -144,7 +144,7 @@ Request a paste without returning the body. It accepts same parameters as all `G
 
 Upload your paste. It accept parameters in form-data:
 
-- `c`: mandatory. The **content** of your paste, text or binary. The maximum allowed size is set by the deployment (`R2_MAX_ALLOWED`). The `filename` in its `Content-Disposition` will be present when fetching the paste.
+- `c`: mandatory. The **content** of your paste, text or binary. The maximum allowed size is set by the deployment (`R2_MAX_ALLOWED`). The `filename` in its `Content-Disposition` will be present when fetching the paste. Note that a single Cloudflare Workers request body is capped at 100 MB — request bodies larger than that are rejected by the platform with HTTP `413 Payload Too Large` before the worker is invoked. For larger files, use the official web UI at `/` or the [`pb`](https://github.com/SharzyL/pastebin-worker/tree/goshujin/scripts) CLI, which transparently chunk the content via the multipart-upload endpoints.
 
 - `e`: optional. The **expiration** time of the paste. After this period of time, the paste is permanently deleted. It should be an integer or a float point number suffixed with an optional unit (seconds by default). Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). For example, `360.25` means 360.25 seconds, and `25d` means 25 days. The actual expiration might be shorter than specified expiration due to limitations imposed by the administrator. If unspecified, a default expiration time setting is used.
 
@@ -180,7 +180,7 @@ If error occurs, the worker returns status code different from `200`:
 
 - `400`: your request is in bad format.
 - `409`: the name is already used.
-- `413`: the content is too large.
+- `413`: the request body exceeds Cloudflare's 100 MB per-request cap (returned by the platform before the worker runs), or the content exceeds the deployment's `R2_MAX_ALLOWED`.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
 
 ## **PUT** `/<name>:<passwd>`
@@ -194,7 +194,7 @@ If error occurs, the worker returns status code different from `200`:
 - `400`: your request is in bad format.
 - `403`: your password is not correct.
 - `404`: the paste of given name is not found.
-- `413`: the content is too large.
+- `413`: the request body exceeds Cloudflare's 100 MB per-request cap (returned by the platform before the worker runs), or the content exceeds the deployment's `R2_MAX_ALLOWED`.
 - `500`: unexpected exception. You may report this to the author to give it a fix.
 
 ## DELETE `/<name>:<passwd>`

--- a/doc/curl.md
+++ b/doc/curl.md
@@ -242,16 +242,24 @@ Deletion may take a few seconds to propagate globally.
 - The maximum allowed upload size is set per deployment via `R2_MAX_ALLOWED`.
   Exceeding it returns HTTP `413`.
 
+- A single HTTP request body is capped at **100 MB** by Cloudflare Workers
+  (HTTP `413 Payload Too Large` is returned before the request ever reaches
+  the worker), regardless of the deployment's `R2_MAX_ALLOWED`. To upload
+  larger files, use the web UI at `{{BASE_URL}}` or the
+  [`pb`](https://github.com/SharzyL/pastebin-worker/tree/goshujin/scripts)
+  CLI — both automatically switch to a multipart upload that streams 5 MiB
+  chunks through the `/mpu/*` endpoints.
+
 ## Common errors
 
-| Status | Meaning                                                  |
-| -----: | -------------------------------------------------------- |
-|  `400` | Malformed request (bad field, illegal name, bad expire). |
-|  `403` | Wrong password when updating or deleting.                |
-|  `404` | Paste not found, or already expired.                     |
-|  `409` | Custom name is already in use.                           |
-|  `413` | Content exceeds the configured max size.                 |
-|  `500` | Unexpected server error — please report it.              |
+| Status | Meaning                                                                                                                                                 |
+| -----: | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|  `400` | Malformed request (bad field, illegal name, bad expire).                                                                                                |
+|  `403` | Wrong password when updating or deleting.                                                                                                               |
+|  `404` | Paste not found, or already expired.                                                                                                                    |
+|  `409` | Custom name is already in use.                                                                                                                          |
+|  `413` | Request body exceeds 100 MB (platform cap, intercepted by Cloudflare before reaching the worker), or content exceeds the deployment's `R2_MAX_ALLOWED`. |
+|  `500` | Unexpected server error — please report it.                                                                                                             |
 
 For the full HTTP API including `HEAD`, `OPTIONS`, response headers, and edge
 cases, see [api.md]({{BASE_URL}}/doc/api).

--- a/doc/skill.md
+++ b/doc/skill.md
@@ -72,6 +72,12 @@ curl -X DELETE                   <manageUrl>
 
 - Default expiration is `{{DEFAULT_EXPIRATION}}`, max `{{MAX_EXPIRATION}}`. Pastes are deleted on expiry.
 - Max upload size is `{{R2_MAX_ALLOWED}}`.
+- A single request body is capped at 100 MB by Cloudflare (you get
+  HTTP `413 Payload Too Large` back, returned by the platform before the
+  worker runs). Files larger than 100 MB therefore cannot be sent via a
+  single `curl -Fc=@…` — use the web UI at `{{BASE_URL}}` or the `pb` CLI
+  (see [scripts/](https://github.com/SharzyL/pastebin-worker/tree/goshujin/scripts)),
+  both of which split large files automatically.
 - Treat the service as ephemeral storage — do not rely on it for archival.
 
 ## Full docs

--- a/frontend/components/PasteInputPanel.tsx
+++ b/frontend/components/PasteInputPanel.tsx
@@ -2,7 +2,7 @@ import type { CardProps } from "./ui/index.js"
 import { Card, CardBody, Tab, Tabs } from "./ui/index.js"
 import type { DragEvent } from "react"
 import { useRef, useState } from "react"
-import { formatSize } from "../utils/utils.js"
+import { formatSize, verifyFileSize } from "../utils/utils.js"
 import { XIcon } from "./icons.js"
 import { cardOverrides, tst } from "../utils/overrides.js"
 import { CodeEditor } from "./CodeEditor.js"
@@ -21,14 +21,32 @@ interface PasteEditorProps extends CardProps {
   isPasteLoading: boolean
   state: PasteEditState
   onStateChange: (state: PasteEditState) => void
+  config: Env
+  showModal: (title: string, content: string) => void
 }
 
-export function PasteInputPanel({ isPasteLoading, state, onStateChange, ...rest }: PasteEditorProps) {
+export function PasteInputPanel({
+  isPasteLoading,
+  state,
+  onStateChange,
+  config,
+  showModal,
+  ...rest
+}: PasteEditorProps) {
   const fileInput = useRef<HTMLInputElement>(null)
   const [isDragged, setDragged] = useState<boolean>(false)
   const [isEditDragged, setEditDragged] = useState<boolean>(false)
 
   function setFile(file: File | null) {
+    if (file) {
+      const [ok, msg] = verifyFileSize(file.size, config)
+      if (!ok) {
+        showModal("File too large", msg)
+        // also reset the underlying input so picking the same file again re-triggers onChange
+        if (fileInput.current) fileInput.current.value = ""
+        return
+      }
+    }
     onStateChange({ ...state, editKind: "file", file })
   }
 

--- a/frontend/components/UploadedPanel.tsx
+++ b/frontend/components/UploadedPanel.tsx
@@ -2,16 +2,29 @@ import type React from "react"
 import { useState } from "react"
 
 import type { CardProps } from "./ui/index.js"
-import { Card, CardBody, CardHeader, CircularProgress, Divider, Input, Tooltip, mergeClasses } from "./ui/index.js"
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  CircularProgress,
+  Divider,
+  Input,
+  Tooltip,
+  mergeClasses,
+} from "./ui/index.js"
 
 import type { PasteResponse } from "../../shared/interfaces.js"
 import { tst } from "../utils/overrides.js"
+import type { UploadProgress } from "../utils/uploader.js"
+import { formatSize } from "../utils/utils.js"
 import { CopyWidget } from "./CopyWidget.js"
 import { ChevronDownIcon, InfoIcon } from "./icons.js"
 
 interface UploadedPanelProps extends CardProps {
   isLoading: boolean
-  loadingProgress?: number
+  loadingProgress?: UploadProgress
+  onCancel?: () => void
   pasteResponse?: PasteResponse
   encryptionKey?: string
   highlightLang?: string
@@ -79,6 +92,7 @@ function UrlTooltip({ desc, flags }: { desc?: React.ReactNode; flags?: { syntax:
 export function UploadedPanel({
   isLoading,
   loadingProgress,
+  onCancel,
   pasteResponse,
   className,
   encryptionKey,
@@ -119,12 +133,21 @@ export function UploadedPanel({
       <Divider />
       <CardBody>
         {isLoading ? (
-          <div className={"min-h-[5rem] w-full relative"}>
+          <div className="w-full flex flex-col items-center justify-center gap-2 py-4">
             <CircularProgress
               aria-label={"Loading..."}
-              value={loadingProgress ?? 50}
-              className={"absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"}
+              value={loadingProgress ? (100 * loadingProgress.doneBytes) / Math.max(loadingProgress.totalBytes, 1) : 50}
             />
+            {loadingProgress && (
+              <span className="text-sm text-foreground-500 tabular-nums">
+                Uploaded {formatSize(loadingProgress.doneBytes)} / {formatSize(loadingProgress.totalBytes)}
+              </span>
+            )}
+            {onCancel && (
+              <Button size="sm" variant="ghost" onPress={onCancel} className="mt-1">
+                Cancel
+              </Button>
+            )}
           </div>
         ) : (
           pasteResponse && (

--- a/frontend/pages/PasteBin.tsx
+++ b/frontend/pages/PasteBin.tsx
@@ -147,7 +147,6 @@ export function PasteBin({ config }: { config: Env }) {
 
   function onCancelUpload() {
     uploadAbortRef.current?.abort()
-    // TODO: also call a worker /mpu/abort endpoint to free orphaned R2 parts
   }
 
   function onStartDelete() {

--- a/frontend/pages/PasteBin.tsx
+++ b/frontend/pages/PasteBin.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useTransition } from "react"
+import { useEffect, useRef, useState, useTransition } from "react"
 
 import { Link } from "../components/ui/index.js"
 
@@ -17,6 +17,7 @@ import { PASSWD_SEP, MAX_URL_REDIRECT_LEN } from "../../shared/constants.js"
 import { verifyExpiration, verifyManageUrl, getMaxExpirationReadable } from "../utils/utils.js"
 import { verifyName, verifyPassword, isLegalUrl } from "../../shared/verify.js"
 import { useNameAvailability } from "../utils/useNameAvailability.js"
+import type { UploadProgress } from "../utils/uploader.js"
 import { uploadPaste } from "../utils/uploader.js"
 import { tst } from "../utils/overrides.js"
 
@@ -43,7 +44,8 @@ export function PasteBin({ config }: { config: Env }) {
   const [uploadedEncryptionKey, setUploadedEncryptionKey] = useState<string | undefined>(undefined)
 
   const [isUploadPending, startUpload] = useTransition()
-  const [loadingProgress, setLoadingProgress] = useState<number | undefined>(undefined)
+  const [loadingProgress, setLoadingProgress] = useState<UploadProgress | undefined>(undefined)
+  const uploadAbortRef = useRef<AbortController | null>(null)
   const [isInitPasteLoading, startFetchingInitPaste] = useTransition()
 
   const [_, modeSelection, setModeSelection] = useDarkModeSelection()
@@ -117,6 +119,11 @@ export function PasteBin({ config }: { config: Env }) {
   }, [])
 
   function onStartUpload() {
+    const controller = new AbortController()
+    uploadAbortRef.current = controller
+    // Clear any previous result so a failed/cancelled retry doesn't show stale URLs.
+    setPasteResponse(undefined)
+    setUploadedEncryptionKey(undefined)
     startUpload(async () => {
       try {
         const uploaded = await uploadPaste(
@@ -125,12 +132,22 @@ export function PasteBin({ config }: { config: Env }) {
           setUploadedEncryptionKey,
           config,
           setLoadingProgress,
+          controller.signal,
         )
         setPasteResponse(uploaded)
       } catch (e) {
-        handleError("Error on Uploading Paste", e as Error)
+        if ((e as Error).name !== "AbortError") {
+          handleError("Error on Uploading Paste", e as Error)
+        }
+      } finally {
+        if (uploadAbortRef.current === controller) uploadAbortRef.current = null
       }
     })
+  }
+
+  function onCancelUpload() {
+    uploadAbortRef.current?.abort()
+    // TODO: also call a worker /mpu/abort endpoint to free orphaned R2 parts
   }
 
   function onStartDelete() {
@@ -257,6 +274,8 @@ export function PasteBin({ config }: { config: Env }) {
           isPasteLoading={isInitPasteLoading}
           state={editorState}
           onStateChange={setEditorState}
+          config={config}
+          showModal={showModal}
           className="mt-6 mb-4 mx-2 lg:mx-0"
         />
         <div className="flex flex-col items-start lg:flex-row gap-4 mx-2 lg:mx-0">
@@ -272,6 +291,7 @@ export function PasteBin({ config }: { config: Env }) {
             <UploadedPanel
               isLoading={isUploadPending}
               loadingProgress={loadingProgress}
+              onCancel={onCancelUpload}
               pasteResponse={pasteResponse}
               encryptionKey={uploadedEncryptionKey}
               highlightLang={editorState.editKind === "edit" ? editorState.editHighlightLang : undefined}

--- a/frontend/utils/uploader.ts
+++ b/frontend/utils/uploader.ts
@@ -16,14 +16,21 @@ async function genAndEncrypt(scheme: EncryptionScheme, content: string | Uint8Ar
 
 const encryptionScheme: EncryptionScheme = "AES-GCM"
 
-const minChunkSize = 5 * 1024 * 1024
+const mpuChunkSize = 5 * 1024 * 1024
+const mpuThreshold = 5 * 1024 * 1024
+
+export interface UploadProgress {
+  doneBytes: number
+  totalBytes: number
+}
 
 export async function uploadPaste(
   pasteSetting: PasteSetting,
   editorState: PasteEditState,
   onEncryptionKeyChange: (k: string | undefined) => void, // we only generate key on upload, so need a callback of key generation
   config: Env,
-  onProgress?: (progress: number | undefined) => void,
+  onProgress?: (progress: UploadProgress | undefined) => void,
+  signal?: AbortSignal,
 ): Promise<PasteResponse> {
   async function constructContent(): Promise<File> {
     if (editorState.editKind === "file") {
@@ -67,15 +74,16 @@ export async function uploadPaste(
   }
 
   const contentLength = options.content.size
+  const reportProgress = (doneBytes: number, totalBytes: number) => {
+    if (onProgress) onProgress({ doneBytes, totalBytes })
+  }
 
   try {
-    if (contentLength < 5 * 1024 * 1024) {
-      return await uploadNormal(config.DEPLOY_URL, options)
+    if (onProgress) onProgress({ doneBytes: 0, totalBytes: contentLength })
+    if (contentLength <= mpuThreshold) {
+      return await uploadNormal(config.DEPLOY_URL, options, reportProgress, signal)
     } else {
-      if (onProgress) onProgress(0)
-      return await uploadMPU(config.DEPLOY_URL, minChunkSize, options, (doneBytes, allBytes) => {
-        if (onProgress) onProgress((100 * doneBytes) / allBytes)
-      })
+      return await uploadMPU(config.DEPLOY_URL, mpuChunkSize, options, reportProgress, undefined, signal)
     }
   } catch (e) {
     if (e instanceof UploadError) {

--- a/frontend/utils/utils.ts
+++ b/frontend/utils/utils.ts
@@ -1,5 +1,5 @@
 import { PASSWD_SEP } from "../../shared/constants.js"
-import { parseExpiration, parseExpirationReadable } from "../../shared/parsers.js"
+import { parseExpiration, parseExpirationReadable, parseSize } from "../../shared/parsers.js"
 import { verifyExpiration as verifyExpirationShared } from "../../shared/verify.js"
 
 export function getMaxExpirationSeconds(config: Env): number {
@@ -11,6 +11,12 @@ export function getMaxExpirationReadable(config: Env): string {
 }
 
 export { ErrorWithTitle } from "./errors.js"
+
+export function verifyFileSize(size: number, config: Env): [boolean, string] {
+  const max = parseSize(config.R2_MAX_ALLOWED)
+  if (max === null || size <= max) return [true, ""]
+  return [false, `File too large (${formatSize(size)} > ${formatSize(max)})`]
+}
 
 export function formatSize(size: number): string {
   if (!size) return "0"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ This directory contains a set of scripts that facilitate the usage and developme
 
 This is a wrapper script to make it easier to use our pastebin.
 
-**Requirements**: `bash`, `jq`, `getopt`, `curl`
+**Requirements**: `python3` (>=3.9) with the `requests` package available
 
 **Installation**: download `pb` to your `PATH` and give it execution permission. For example:
 
@@ -29,19 +29,19 @@ Usage:
   pb [-h|--help]
     print this help message
 
-  pb [p|post] [OPTIONS] [-f] FILE
-    upload your text to pastebin, if neither 'FILE' and 'CONTENT' are given,
-    read the paste from stdin.
+  pb [p|post] [OPTIONS]
+    upload your text to pastebin, if neither '-f FILE' nor '-c CONTENT' are
+    given, read the paste from stdin.
 
-  pb [u|update] NAME[:PASSWD]
-    Update your text to pastebin, if neither 'FILE' and 'CONTENT' are given,
-    read the paste from stdin. If 'PASSWD' is not given, try to read password
-    from the history file.
+  pb [u|update] [OPTIONS] NAME[:PASSWD]
+    Update your text to pastebin, if neither '-f FILE' nor '-c CONTENT' are
+    given, read the paste from stdin. If 'PASSWD' is not given, try to read
+    password from the history file.
 
   pb [g|get] [OPTIONS] NAME[.EXT]
     fetch the paste with name 'NAME' and extension 'EXT'
 
-  pb [d|delete] [OPTIONS] NAME
+  pb [d|delete] [OPTIONS] NAME[:PASSWD]
     delete the paste with name 'NAME'
 
 Options:
@@ -61,15 +61,14 @@ Options:
     -x, --clip              clip the url to the clipboard
 
   get options:
-    -l, --lang LANG         highlight the paste with language 'LANG' in a web page
-    -m, --mime MIME         set the 'Content-Type' header according to mime-type MIME
     -o, --output FILE       output the paste in file 'FILE'
     -u, --url               make a 302 URL redirection
+    --meta                  fetch /m/<name> metadata as pretty JSON
 
   delete options:
     none
 
   general options:
-    -v, --verbose           display the 'underlying' curl command
-    -d, --dry               do a dry run, executing no 'curl' command at all
+    -v, --verbose           log the planned request (method, URL, fields)
+    -d, --dry               do a dry run, sending no HTTP request at all
 ```

--- a/scripts/_pb
+++ b/scripts/_pb
@@ -10,9 +10,16 @@ __pb_hist_names() {
     compadd -- ${(u)${(Oa)names}}
 }
 
-local -a root_args=(
+# Flags accepted at any position (before OR after the action).
+local -a common_args=(
     '(-h --help)'{-h,--help}'[print help]'
+    '(-d --dry)'{-d,--dry}'[dry run]'
+    '(-v --verbose)'{-v,--verbose}'[verbose]'
     '--base-url[Base URL (overrides $PB_DOMAIN)]:url'
+)
+
+local -a root_args=(
+    $common_args
     '1:command:->commands'
     '*::arguments:->arguments'
 )
@@ -30,10 +37,6 @@ case "$state" in
     _describe -t pb-commands 'pb.sh command' cmdlist
     ;;
 (arguments)
-    local -a common_args=(
-        '(-d --dry)'{-d,--dry}'[dry run]'
-        '(-v --verbose)'{-v,--verbose}'[verbose]'
-    )
 
     case ${line[1]} in
     (p|post)

--- a/scripts/_pb
+++ b/scripts/_pb
@@ -1,9 +1,18 @@
 #compdef pb
 
+__pb_hist_names() {
+    local hist_file="${XDG_CONFIG_DIR:-$HOME/.config}/pb_hist"
+    [[ -r "$hist_file" ]] || return
+    local -a names
+    # strip ":passwd", drop empties, reverse (latest first), then dedup keeping first
+    names=(${${(f)"$(<$hist_file)"}%%:*})
+    names=(${names:#})
+    compadd -- ${(u)${(Oa)names}}
+}
+
 local -a root_args=(
-    '(-d --dry)'{-d,--dry}'[dry run]'
-    '(-v --verbose)'{-v,--verbose}'[verbose]'
     '(-h --help)'{-h,--help}'[print help]'
+    '--base-url[Base URL (overrides $PB_DOMAIN)]:url'
     '1:command:->commands'
     '*::arguments:->arguments'
 )
@@ -56,12 +65,11 @@ case "$state" in
 
     (g|get)
         local -a args=(
-            '*:paste name'
+            '*:paste name:__pb_hist_names'
 
-            '(-l --lang)'{-l,--lang}'[Highlight with language in a web page]:language'
-            '(-m --mine)'{-m,--mine}'[Content of the paste]:mimetype'
             '(-o --output)'{-o,--output}'[Output the paste in file]:file:_files'
-            '(-u --url)'{-u,--url}'[Make a 302 redirection]'
+            '(-u --url --meta)'{-u,--url}'[Make a 302 redirection]'
+            '(-u --url --meta)--meta[Fetch /m/<name> metadata as JSON]'
         )
         _arguments -s $args $common_args
         ;;

--- a/scripts/pb
+++ b/scripts/pb
@@ -305,7 +305,8 @@ def upload_mpu(
     paste_name = create["name"]
 
     bar = ProgressBar(total, label="MPU")
-    uploaded_parts = []
+    uploaded_parts: list = []
+    completed = False
     try:
         for i in range(num_parts):
             chunk = body[i * MPU_CHUNK_SIZE : (i + 1) * MPU_CHUNK_SIZE]
@@ -328,36 +329,50 @@ def upload_mpu(
             if not part_resp.ok:
                 die(f"MPU part {i + 1} {part_resp.status_code}: {part_resp.text}")
             uploaded_parts.append(part_resp.json())
-    finally:
-        bar.close()
 
-    complete_params = {"name": paste_name, "key": key, "uploadId": upload_id}
-    complete_data = dict(fields)
-    log_request(
-        "POST" if not is_update else "PUT",
-        f"{domain}/mpu/complete",
-        {**complete_data, "c": "<parts...>"},
-        complete_params,
-    )
-    try:
-        complete_resp = requests.request(
+        complete_params = {"name": paste_name, "key": key, "uploadId": upload_id}
+        complete_data = dict(fields)
+        log_request(
             "POST" if not is_update else "PUT",
             f"{domain}/mpu/complete",
-            params=complete_params,
-            data=complete_data,
-            files={"c": ("paste", json.dumps(uploaded_parts).encode())},
+            {**complete_data, "c": "<parts...>"},
+            complete_params,
         )
-    except requests.RequestException as e:
-        die(f"MPU complete failed: {e}")
-        return
-    if not complete_resp.ok:
-        die(f"MPU complete {complete_resp.status_code}: {complete_resp.text}")
+        try:
+            complete_resp = requests.request(
+                "POST" if not is_update else "PUT",
+                f"{domain}/mpu/complete",
+                params=complete_params,
+                data=complete_data,
+                files={"c": ("paste", json.dumps(uploaded_parts).encode())},
+            )
+        except requests.RequestException as e:
+            die(f"MPU complete failed: {e}")
+            return
+        if not complete_resp.ok:
+            die(f"MPU complete {complete_resp.status_code}: {complete_resp.text}")
 
-    try:
-        payload = complete_resp.json()
-    except ValueError:
-        die(f"non-JSON response from /mpu/complete: {complete_resp.text}")
-        return
+        try:
+            payload = complete_resp.json()
+        except ValueError:
+            die(f"non-JSON response from /mpu/complete: {complete_resp.text}")
+            return
+        completed = True
+    finally:
+        bar.close()
+        # Release R2-side multipart state if we didn't reach complete (chunk failed,
+        # complete failed, Ctrl-C, etc.). Knowing key+uploadId is the auth.
+        if not completed:
+            try:
+                requests.post(
+                    f"{domain}/mpu/abort",
+                    params={"key": key, "uploadId": upload_id},
+                    timeout=5,
+                )
+                logger.info("MPU aborted on server")
+            except requests.RequestException as abort_err:
+                logger.warning(f"MPU abort failed; orphaned parts may remain: {abort_err}")
+
     _finalize_response(payload, clip_flag)
 
 

--- a/scripts/pb
+++ b/scripts/pb
@@ -6,17 +6,21 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import requests
 
 DEFAULT_DOMAIN = "https://shz.al"
 SCRIPT_NAME = "pb"
+MPU_THRESHOLD = 5 * 1024 * 1024  # switch to multipart upload above this size
+MPU_CHUNK_SIZE = 5 * 1024 * 1024  # R2 requires every part except the last to be >=5 MiB
 
 LEVEL_COLORS = {
     logging.DEBUG: "90",
@@ -41,6 +45,82 @@ class ColorFormatter(logging.Formatter):
 
 
 logger = logging.getLogger(SCRIPT_NAME)
+
+
+def _format_size(n: int) -> str:
+    if n >= 1024 * 1024:
+        return f"{n / 1024 / 1024:.1f} MiB"
+    if n >= 1024:
+        return f"{n / 1024:.1f} KiB"
+    return f"{n} B"
+
+
+class ProgressBar:
+    """Single-line progress bar rendered to stderr; no-op when stderr isn't a TTY."""
+
+    def __init__(self, total: int, label: str = "upload") -> None:
+        self.total = total
+        self.done = 0
+        self.label = label
+        # Suppress the bar when verbose logging is on: its per-part debug lines
+        # already trace progress and the \r-redraw would otherwise interleave.
+        self.tty = sys.stderr.isatty() and not logger.isEnabledFor(logging.DEBUG)
+        self.last_render = 0.0
+        self.width = 30
+
+    def update(self, delta: int) -> None:
+        self.done = min(self.done + delta, self.total)
+        self._render(force=self.done >= self.total)
+
+    def _render(self, force: bool = False) -> None:
+        if not self.tty:
+            return
+        now = time.monotonic()
+        if not force and now - self.last_render < 0.1:
+            return
+        self.last_render = now
+        frac = self.done / self.total if self.total > 0 else 1.0
+        filled = int(self.width * frac)
+        if filled >= self.width:
+            bar = "=" * self.width
+        else:
+            bar = "=" * filled + ">" + " " * (self.width - filled - 1)
+        msg = (
+            f"\r{self.label} [{bar}] {_format_size(self.done)} / "
+            f"{_format_size(self.total)} ({frac * 100:.0f}%)"
+        )
+        sys.stderr.write(msg)
+        sys.stderr.flush()
+
+    def close(self) -> None:
+        if self.tty:
+            sys.stderr.write("\n")
+            sys.stderr.flush()
+
+
+class ProgressReader:
+    """File-like wrapper over a bytes buffer; calls on_read(n) as bytes are consumed.
+
+    requests streams from `data=<file-like>` by calling .read(size) repeatedly,
+    so we get fine-grained progress within a single PUT/POST.
+    """
+
+    def __init__(self, buf: bytes, on_read: Callable[[int], None]) -> None:
+        self.buf = buf
+        self.pos = 0
+        self.on_read = on_read
+
+    def __len__(self) -> int:
+        return len(self.buf)
+
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = len(self.buf) - self.pos
+        chunk = self.buf[self.pos : self.pos + size]
+        self.pos += len(chunk)
+        if chunk:
+            self.on_read(len(chunk))
+        return chunk
 
 
 def setup_logger(verbose: bool) -> None:
@@ -131,6 +211,156 @@ def manage_basename(manage_url: str) -> str:
     return manage_url.rstrip("/").rsplit("/", 1)[-1]
 
 
+def _print_json(payload: dict) -> None:
+    """Pretty-print JSON. If `jq` is on PATH, hand off to it for syntax coloring
+    (matching what the old Bash script did); otherwise use stdlib indentation.
+    `jq -C` forces color even when its stdout is not a TTY, so we gate on the
+    real TTY here."""
+    raw = json.dumps(payload, ensure_ascii=False)
+    if shutil.which("jq"):
+        color_flag = "-C" if sys.stdout.isatty() else "-M"
+        try:
+            subprocess.run(["jq", color_flag, "."], input=raw.encode(), check=True)
+            return
+        except (subprocess.CalledProcessError, OSError) as e:
+            logger.debug(f"jq failed, falling back to plain JSON: {e}")
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _finalize_response(payload: dict, clip_flag: bool) -> None:
+    _print_json(payload)
+    manage_url = payload.get("manageUrl")
+    if manage_url:
+        append_history(manage_basename(manage_url))
+    page_url = payload.get("url")
+    if clip_flag and page_url:
+        clip(page_url)
+
+
+def upload_mpu(
+    domain: str,
+    body: bytes,
+    fields: dict,
+    is_update: bool,
+    name: Optional[str],
+    passwd: Optional[str],
+    is_private: bool,
+    expire: Optional[str],
+    dry: bool,
+    clip_flag: bool,
+) -> None:
+    """Multipart upload for files larger than MPU_THRESHOLD.
+
+    For post:   POST /mpu/create?n=&p=&e=
+    For update: POST /mpu/create-update?name=&password=&e=
+    Then PUT /mpu/resume?key=&uploadId=&partNumber= for each 5 MiB chunk.
+    Finally POST /mpu/complete?name=&key=&uploadId= with `c=<json parts list>`.
+    """
+    total = len(body)
+    num_parts = max(1, math.ceil(total / MPU_CHUNK_SIZE))
+
+    if is_update:
+        create_url = f"{domain}/mpu/create-update"
+        create_params: dict = {"name": name, "password": passwd}
+    else:
+        create_url = f"{domain}/mpu/create"
+        create_params = {}
+        if name:
+            create_params["n"] = name.lstrip("~")
+        if is_private:
+            create_params["p"] = "1"
+    if expire:
+        create_params["e"] = expire
+
+    masked_create_params = dict(create_params)
+    if "password" in masked_create_params:
+        masked_create_params["password"] = "***"
+    log_request("POST", create_url, {}, masked_create_params)
+    logger.info(
+        f"using MPU: {_format_size(total)} in {num_parts} part(s) of "
+        f"{_format_size(MPU_CHUNK_SIZE)}"
+    )
+    if dry:
+        for i in range(num_parts):
+            chunk_size = min(MPU_CHUNK_SIZE, total - i * MPU_CHUNK_SIZE)
+            log_request(
+                "PUT",
+                f"{domain}/mpu/resume",
+                {},
+                {"partNumber": i + 1, "size": chunk_size},
+            )
+        log_request("POST", f"{domain}/mpu/complete", {**fields, "c": "<parts...>"}, {})
+        return
+
+    try:
+        create_resp = requests.post(create_url, params=create_params)
+    except requests.RequestException as e:
+        die(f"MPU create failed: {e}")
+        return
+    if not create_resp.ok:
+        die(f"MPU create {create_resp.status_code}: {create_resp.text}")
+    create = create_resp.json()
+    key = create["key"]
+    upload_id = create["uploadId"]
+    paste_name = create["name"]
+
+    bar = ProgressBar(total, label="MPU")
+    uploaded_parts = []
+    try:
+        for i in range(num_parts):
+            chunk = body[i * MPU_CHUNK_SIZE : (i + 1) * MPU_CHUNK_SIZE]
+            logger.debug(f"PUT part {i + 1}/{num_parts}  size={len(chunk)}")
+            reader = ProgressReader(chunk, bar.update)
+            try:
+                part_resp = requests.put(
+                    f"{domain}/mpu/resume",
+                    params={
+                        "key": key,
+                        "uploadId": upload_id,
+                        "partNumber": i + 1,
+                    },
+                    data=reader,
+                    headers={"Content-Length": str(len(chunk))},
+                )
+            except requests.RequestException as e:
+                die(f"MPU part {i + 1} failed: {e}")
+                return
+            if not part_resp.ok:
+                die(f"MPU part {i + 1} {part_resp.status_code}: {part_resp.text}")
+            uploaded_parts.append(part_resp.json())
+    finally:
+        bar.close()
+
+    complete_params = {"name": paste_name, "key": key, "uploadId": upload_id}
+    complete_data = dict(fields)
+    log_request(
+        "POST" if not is_update else "PUT",
+        f"{domain}/mpu/complete",
+        {**complete_data, "c": "<parts...>"},
+        complete_params,
+    )
+    try:
+        complete_resp = requests.request(
+            "POST" if not is_update else "PUT",
+            f"{domain}/mpu/complete",
+            params=complete_params,
+            data=complete_data,
+            files={"c": ("paste", json.dumps(uploaded_parts).encode())},
+        )
+    except requests.RequestException as e:
+        die(f"MPU complete failed: {e}")
+        return
+    if not complete_resp.ok:
+        die(f"MPU complete {complete_resp.status_code}: {complete_resp.text}")
+
+    try:
+        payload = complete_resp.json()
+    except ValueError:
+        die(f"non-JSON response from /mpu/complete: {complete_resp.text}")
+        return
+    _finalize_response(payload, clip_flag)
+
+
 def post_or_put(
     method: str,
     url: str,
@@ -172,15 +402,7 @@ def post_or_put(
         die(f"non-JSON response: {resp.text}")
         return
 
-    print(json.dumps(payload, indent=2, ensure_ascii=False))
-
-    manage_url = payload.get("manageUrl")
-    if manage_url:
-        append_history(manage_basename(manage_url))
-
-    page_url = payload.get("url")
-    if clip_flag and page_url:
-        clip(page_url)
+    _finalize_response(payload, clip_flag)
 
 
 def parse_name_passwd(arg: str) -> tuple[str, Optional[str]]:
@@ -198,6 +420,27 @@ def cmd_post(args: argparse.Namespace, domain: str) -> None:
 
     file = args.file or args.file_pos
     body = read_content(file, args.content)
+
+    if len(body) > MPU_THRESHOLD:
+        mpu_fields: dict = {}
+        if args.expire:
+            mpu_fields["e"] = args.expire
+        if args.passwd:
+            mpu_fields["s"] = args.passwd
+        upload_mpu(
+            domain,
+            body,
+            mpu_fields,
+            is_update=False,
+            name=args.name,
+            passwd=None,
+            is_private=bool(args.private),
+            expire=args.expire,
+            dry=args.dry,
+            clip_flag=args.clip,
+        )
+        return
+
     fields: dict = {}
     if args.expire:
         fields["e"] = args.expire
@@ -221,6 +464,27 @@ def cmd_update(args: argparse.Namespace, domain: str) -> None:
         )
 
     body = read_content(args.file, args.content)
+
+    if len(body) > MPU_THRESHOLD:
+        mpu_fields: dict = {}
+        if args.expire:
+            mpu_fields["e"] = args.expire
+        if args.passwd:
+            mpu_fields["s"] = args.passwd
+        upload_mpu(
+            domain,
+            body,
+            mpu_fields,
+            is_update=True,
+            name=name,
+            passwd=passwd,
+            is_private=False,
+            expire=args.expire,
+            dry=args.dry,
+            clip_flag=args.clip,
+        )
+        return
+
     fields: dict = {}
     if args.expire:
         fields["e"] = args.expire
@@ -269,7 +533,7 @@ def cmd_get(args: argparse.Namespace, domain: str) -> None:
         except ValueError:
             die(f"non-JSON response from /m/: {resp.text}")
             return
-        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        _print_json(payload)
         return
 
     if args.output:
@@ -302,23 +566,44 @@ def cmd_delete(args: argparse.Namespace, domain: str) -> None:
         die(f"{resp.status_code}: {resp.text}")
 
 
-def add_common(p: argparse.ArgumentParser) -> None:
-    p.add_argument("-v", "--verbose", action="store_true", help="verbose output")
-    p.add_argument(
-        "-d", "--dry", action="store_true", help="dry run, do not send the request"
-    )
+def build_common_parser() -> argparse.ArgumentParser:
+    """Parent parser holding flags that may appear before OR after the action.
 
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog=SCRIPT_NAME,
-        description="pastebin-worker command-line client",
+    Using default=argparse.SUPPRESS means subparser parsing does NOT clobber
+    values already set by the main parser when the same flag appears before
+    the action.
+    """
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="verbose output",
     )
-    parser.add_argument(
+    common.add_argument(
+        "-d",
+        "--dry",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="dry run, do not send the request",
+    )
+    common.add_argument(
         "--base-url",
         dest="base_url",
         metavar="URL",
+        default=argparse.SUPPRESS,
         help=f"base URL of the pastebin instance (overrides $PB_DOMAIN, default: {DEFAULT_DOMAIN})",
+    )
+    return common
+
+
+def build_parser() -> argparse.ArgumentParser:
+    common = build_common_parser()
+    parser = argparse.ArgumentParser(
+        prog=SCRIPT_NAME,
+        description="pastebin-worker command-line client",
+        parents=[common],
     )
     sub = parser.add_subparsers(dest="action", required=True, metavar="ACTION")
 
@@ -328,6 +613,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="upload a paste",
         description="Upload a paste. If neither FILE nor -c/--content is given, "
         "the paste content is read from stdin.",
+        parents=[common],
     )
     p_post.add_argument("-c", "--content", help="inline content of the paste")
     p_post.add_argument("-e", "--expire", help="expiration time (e.g. 60, 1h, 7d)")
@@ -343,7 +629,6 @@ def build_parser() -> argparse.ArgumentParser:
     p_post.add_argument(
         "file_pos", nargs="?", metavar="FILE", help="read paste from file (positional)"
     )
-    add_common(p_post)
     p_post.set_defaults(func=cmd_post)
 
     p_update = sub.add_parser(
@@ -353,6 +638,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Update an existing paste. If neither -f/--file nor -c/--content "
         "is given, the new content is read from stdin. If PASSWD is omitted, it is "
         "looked up from the history file.",
+        parents=[common],
     )
     p_update.add_argument("target", help="NAME[:PASSWD]")
     p_update.add_argument("-c", "--content", help="inline content of the paste")
@@ -362,10 +648,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_update.add_argument(
         "-x", "--clip", action="store_true", help="copy URL to clipboard"
     )
-    add_common(p_update)
     p_update.set_defaults(func=cmd_update)
 
-    p_get = sub.add_parser("get", aliases=["g"], help="fetch a paste")
+    p_get = sub.add_parser(
+        "get",
+        aliases=["g"],
+        help="fetch a paste",
+        parents=[common],
+    )
     p_get.add_argument("name", help="NAME[.EXT]")
     p_get.add_argument("-o", "--output", help="write to FILE instead of stdout")
     p_get.add_argument(
@@ -374,12 +664,15 @@ def build_parser() -> argparse.ArgumentParser:
     p_get.add_argument(
         "--meta", action="store_true", help="fetch /m/<name> metadata as pretty JSON"
     )
-    add_common(p_get)
     p_get.set_defaults(func=cmd_get)
 
-    p_del = sub.add_parser("delete", aliases=["d"], help="delete a paste")
+    p_del = sub.add_parser(
+        "delete",
+        aliases=["d"],
+        help="delete a paste",
+        parents=[common],
+    )
     p_del.add_argument("target", help="NAME[:PASSWD]")
-    add_common(p_del)
     p_del.set_defaults(func=cmd_delete)
 
     return parser
@@ -388,13 +681,25 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[list] = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
-    setup_logger(getattr(args, "verbose", False))
+    # These flags use default=argparse.SUPPRESS so that placing them before
+    # the action does not get clobbered by the subparser. Fill in fallbacks.
+    args.verbose = getattr(args, "verbose", False)
+    args.dry = getattr(args, "dry", False)
+    base_url = getattr(args, "base_url", None)
+    setup_logger(args.verbose)
 
-    domain = (args.base_url or os.environ.get("PB_DOMAIN") or DEFAULT_DOMAIN).rstrip(
-        "/"
-    )
+    domain = (base_url or os.environ.get("PB_DOMAIN") or DEFAULT_DOMAIN).rstrip("/")
     args.func(args, domain)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        # Ensure any in-flight progress bar leaves the cursor on a fresh line.
+        if sys.stderr.isatty():
+            sys.stderr.write("\n")
+            sys.stderr.flush()
+        if logger.handlers:
+            logger.warning("interrupted")
+        sys.exit(130)

--- a/scripts/pb
+++ b/scripts/pb
@@ -1,348 +1,400 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
+"""pb: command-line client for pastebin-worker."""
 
-domain="${PB_DOMAIN:-https://shz.al}"
-hist_file="${XDG_CONFIG_DIR:-$HOME/.config}/pb_hist"
+from __future__ import annotations
 
-script_name=${0##*/}
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
 
-_print_with_color() {
-    color=$1
-    shift
-    [ -t 2 ] && printf "\x1b[0;%sm" "$color" >&2
-    echo -n "$*" >&2
-    [ -t 2 ] && printf "\x1b[0m\n" >&2
+import requests
+
+DEFAULT_DOMAIN = "https://shz.al"
+SCRIPT_NAME = "pb"
+
+LEVEL_COLORS = {
+    logging.DEBUG: "90",
+    logging.INFO: "0",
+    logging.WARNING: "33",
+    logging.ERROR: "31",
+    logging.CRITICAL: "31",
 }
 
-_die() {
-    _print_with_color 31 "$@"
-    exit 1
-}
 
-[ -d "${hist_file%/*}" ] || mkdir -p "${hist_file%/*}" || _die "cannot create directory for '$hist_file'"
-touch "$hist_file" || _die "cannot create history file '$hist_file'"
+class ColorFormatter(logging.Formatter):
+    def __init__(self, use_color: bool) -> None:
+        super().__init__(fmt="%(name)s: %(message)s")
+        self.use_color = use_color
 
-_verbose() {
-    _print_with_color 90 "$script_name: $*"
-}
+    def format(self, record: logging.LogRecord) -> str:
+        msg = super().format(record)
+        if not self.use_color:
+            return msg
+        code = LEVEL_COLORS.get(record.levelno, "0")
+        return f"\x1b[0;{code}m{msg}\x1b[0m"
 
-_clip() {
-    if [ -x "$(command -v pbcopy)" ]; then
-        echo "$@" | pbcopy
-    elif [ -x "$(command -v xclip)" ]; then
-        echo "$@" | xclip -selection clipboard
-    elif [ -x "$(command -v xsel)" ]; then
-        echo "$@" | xsel -b
-    elif [ -x "$(command -v wl-copy)" ]; then
-        echo "$@" | wl-copy
-    else
-        _verbose "Cannot find a clipboard tool. Requires one of 'pbcopy' (macOS), 'xclip' (xorg), 'xsel' (xorg) or 'wl-copy' (wayland)."
+
+logger = logging.getLogger(SCRIPT_NAME)
+
+
+def setup_logger(verbose: bool) -> None:
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(ColorFormatter(use_color=sys.stderr.isatty()))
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+
+
+def die(msg: str) -> "Optional[None]":
+    logger.error(msg)
+    sys.exit(1)
+
+
+def history_path() -> Path:
+    base = os.environ.get("XDG_CONFIG_DIR") or os.path.expanduser("~/.config")
+    return Path(base) / "pb_hist"
+
+
+def ensure_history() -> Path:
+    p = history_path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch(exist_ok=True)
+    except OSError as e:
+        die(f"cannot create history file '{p}': {e}")
+    return p
+
+
+def append_history(entry: str) -> None:
+    p = ensure_history()
+    with p.open("a") as f:
+        f.write(entry + "\n")
+
+
+def lookup_passwd(name: str) -> Optional[str]:
+    p = ensure_history()
+    found: Optional[str] = None
+    with p.open() as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line.startswith(f"{name}:"):
+                found = line.split(":", 1)[1]
+    return found
+
+
+def clip(text: str) -> None:
+    candidates = [
+        ("pbcopy", []),
+        ("xclip", ["-selection", "clipboard"]),
+        ("xsel", ["-b"]),
+        ("wl-copy", []),
+    ]
+    for cmd, args in candidates:
+        if shutil.which(cmd):
+            try:
+                subprocess.run([cmd, *args], input=text.encode(), check=True)
+                logger.info(f"'{text}' is copied to your clipboard")
+            except subprocess.CalledProcessError as e:
+                logger.warning(f"clipboard command '{cmd}' failed: {e}")
+            return
+    logger.warning(
+        "Cannot find a clipboard tool. Requires one of "
+        "'pbcopy' (macOS), 'xclip' (xorg), 'xsel' (xorg) or 'wl-copy' (wayland)."
+    )
+
+
+def read_content(file: Optional[str], content: Optional[str]) -> bytes:
+    if content is not None and file is not None:
+        die("cannot set both 'content' and 'file'")
+    if file is not None:
+        try:
+            return Path(file).read_bytes()
+        except OSError as e:
+            die(f"cannot read file '{file}': {e}")
+    if content is not None:
+        return content.encode()
+    return sys.stdin.buffer.read()
+
+
+def log_request(method: str, url: str, fields: dict, params: dict) -> None:
+    masked = {k: ("***" if k == "s" else v) for k, v in fields.items()}
+    logger.debug(f"{method} {url}  fields={masked}  params={params}")
+
+
+def manage_basename(manage_url: str) -> str:
+    return manage_url.rstrip("/").rsplit("/", 1)[-1]
+
+
+def post_or_put(
+    method: str,
+    url: str,
+    fields: dict,
+    body: Optional[bytes],
+    verbose: bool,
+    dry: bool,
+    clip_flag: bool,
+    log_url: Optional[str] = None,
+) -> None:
+    files: dict = {}
+    data: dict = {}
+    for k, v in fields.items():
+        data[k] = v
+    if body is not None:
+        files["c"] = ("paste", body)
+
+    log_request(
+        method,
+        log_url or url,
+        {**fields, "c": "<...>" if body is not None else None},
+        {},
+    )
+    if dry:
         return
-    fi
-    _verbose "'$*' is copied to your clipboard"
-}
 
-curl_code() {
-    status_code=$(curl -sS -w '%{response_code}' "$@")
-    if [ "$status_code" != '200' ] && [ "$status_code" != '302' ]; then
-        return 1
-    fi
-}
+    try:
+        resp = requests.request(method, url, data=data, files=files or None)
+    except requests.RequestException as e:
+        die(f"request failed: {e}")
+        return  # for type-checker; die() exits
 
-main() {
-    action="$1"
-    shift
-    case "$action" in
-        (p|post  ) pb_post "$@";;
-        (u|update) pb_update "$@";;
-        (d|delete) pb_delete "$@";;
-        (g|get   ) pb_get "$@";;
-        (-h|--help) usage;;
-        (*) _die "no action given. try '$script_name' -h for more information"
-    esac
-}
+    if resp.status_code not in (200, 302):
+        die(f"{resp.status_code}: {resp.text}")
 
-usage() {
-    cat <<-EOF
-Usage:
-  ${script_name} [-h|--help]
-    print this help message
+    try:
+        payload = resp.json()
+    except ValueError:
+        die(f"non-JSON response: {resp.text}")
+        return
 
-  ${script_name} [p|post] [OPTIONS] [-f] FILE
-    upload your text to pastebin, if neither 'FILE' and 'CONTENT' are given,
-    read the paste from stdin.
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
 
-  ${script_name} [u|update] NAME[:PASSWD]
-    Update your text to pastebin, if neither 'FILE' and 'CONTENT' are given,
-    read the paste from stdin. If 'PASSWD' is not given, try to read password
-    from the history file.
+    manage_url = payload.get("manageUrl")
+    if manage_url:
+        append_history(manage_basename(manage_url))
 
-  ${script_name} [g|get] [OPTIONS] NAME[.EXT]
-    fetch the paste with name 'NAME' and extension 'EXT'
+    page_url = payload.get("url")
+    if clip_flag and page_url:
+        clip(page_url)
 
-  ${script_name} [d|delete] [OPTIONS] NAME
-    delete the paste with name 'NAME'
 
-Options:
-  post options:
-    -c, --content CONTENT   the content of the paste
-    -e, --expire SECONDS    the expiration time of the paste (in seconds)
-    -n, --name NAME         the name of the paste
-    -s, --passwd PASSWD     the password
-    -p, --private           make the generated paste name longer for better privacy
-    -x, --clip              clip the url to the clipboard
+def parse_name_passwd(arg: str) -> tuple[str, Optional[str]]:
+    if ":" in arg:
+        name, passwd = arg.split(":", 1)
+        return name, passwd
+    return arg, None
 
-  update options:
-    -f, --file FILE         read the paste from file
-    -c, --content CONTENT   the content of the paste
-    -e, --expire SECONDS    the expiration time of the paste (in seconds)
-    -s, --passwd PASSWD     the password
-    -x, --clip              clip the url to the clipboard
 
-  get options:
-    -l, --lang LANG         highlight the paste with language 'LANG' in a web page
-    -m, --mime MIME         set the 'Content-Type' header according to mime-type MIME
-    -o, --output FILE       output the paste in file 'FILE'
-    -u, --url               make a 302 URL redirection
+def cmd_post(args: argparse.Namespace, domain: str) -> None:
+    if args.private and args.name:
+        die("cannot set both 'private' and 'name'")
+    if args.file and args.file_pos:
+        die("cannot specify FILE both as positional argument and via '-f'")
 
-  delete options:
-    none
+    file = args.file or args.file_pos
+    body = read_content(file, args.content)
+    fields: dict = {}
+    if args.expire:
+        fields["e"] = args.expire
+    if args.name:
+        fields["n"] = args.name
+    if args.passwd:
+        fields["s"] = args.passwd
+    if args.private:
+        fields["p"] = "true"
 
-  general options:
-    -v, --verbose           display the 'underlying' curl command
-    -d, --dry               do a dry run, executing no 'curl' command at all
-EOF
-}
+    post_or_put("POST", f"{domain}/", fields, body, args.verbose, args.dry, args.clip)
 
-pb_post() {
-    # parse args
-    short_args="c:e:n:s:f:vhpxd"
-    long_args="content:,expire:,name:,passwd:,file:,verbose,private,clip,dry"
-    TEMP=$(getopt -o "$short_args" --long "$long_args" -n "$script_name" -- "$@") \
-        || return 1
-    eval set -- "$TEMP";
 
-    local content expire name passwd private verbose clip dry
-    while [[ ${1:0:1} == - ]]; do
-        [[ $1 =~ ^-f|--|--file$ ]]  && {
-            shift 1;
-            if [ -n "$1" ]; then file="$1"; shift 1; continue; fi
-        };
-        [[ $1 =~ ^-c|--content$ ]]  && { content="$2"; shift 2; continue; };
-        [[ $1 =~ ^-e|--expire$ ]]   && { expire="$2"; shift 2; continue; };
-        [[ $1 =~ ^-n|--name$ ]]     && { name="$2"; shift 2; continue; };
-        [[ $1 =~ ^-s|--passwd$ ]]   && { passwd="$2"; shift 2; continue; };
-        [[ $1 =~ ^-p|--private$ ]]  && { private="true"; shift 1; continue; };
-        [[ $1 =~ ^-v|--verbose$ ]]  && { verbose="true"; shift 1; continue; };
-        [[ $1 =~ ^-x|--clip$ ]]     && { clip="true"; shift 1; continue; };
-        [[ $1 =~ ^-d|--dry$ ]]      && { dry="true"; shift 1; continue; };
-        break;
-    done
-    [ "$#" -gt 0 ] && _die "redundant arguments '$*'"
+def cmd_update(args: argparse.Namespace, domain: str) -> None:
+    name, passwd = parse_name_passwd(args.target)
+    if passwd is None:
+        passwd = args.passwd or lookup_passwd(name)
+    if not passwd:
+        die(
+            f"no passwd given, and cannot find passwd in history file '{history_path()}'"
+        )
 
-    # check arguments
-    [ -n "$content" ] && [ -n "$file" ] && _die "cannot set both 'content' and 'file'"
-    [ -n "$file" ] && [ ! -r "$file" ]  && _die "cannot read file '${file}'"
-    [ -n "$private" ] && [ -n "$name" ] && _die "cannot set both 'private' and 'name'"
+    body = read_content(args.file, args.content)
+    fields: dict = {}
+    if args.expire:
+        fields["e"] = args.expire
+    if args.passwd:
+        fields["s"] = args.passwd
 
-    # build arguments
-    declare -a args=("curl_code" "-sS" "$domain")
-    [ -n "$file" ]    && args+=("-Fc=@$file")
-    [ -n "$content" ] && args+=("-Fc=\"$content\"")
-    [ -n "$expire" ]  && args+=("-Fe=\"$expire\"")
-    [ -n "$name" ]    && args+=("-Fn=\"$name\"")
-    [ -n "$passwd" ]  && args+=("-Fs=\"$passwd\"")
-    [ -n "$private" ] && args+=("-Fp=true")
-    [ -z "$content" ] && [ -z "$file" ] && args+=("-Fc=@-")
+    post_or_put(
+        "PUT",
+        f"{domain}/{name}:{passwd}",
+        fields,
+        body,
+        args.verbose,
+        args.dry,
+        args.clip,
+        log_url=f"{domain}/{name}:***",
+    )
 
-    # prepare curl
-    tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' EXIT
 
-    [ -n "$verbose" ] && _verbose "${args[@]}"
+def cmd_get(args: argparse.Namespace, domain: str) -> None:
+    if args.meta:
+        if args.url:
+            die("cannot combine --meta with --url")
+        prefix = "m"
+    elif args.url:
+        prefix = "u"
+    else:
+        prefix = None
+    base = f"{domain}/{prefix}/{args.name}" if prefix else f"{domain}/{args.name}"
 
-    # curl if not dry-run
-    if [ -z "$dry" ]; then
-        "${args[@]}" -o "$tmp_file" || _die "$status_code: $(cat "$tmp_file")"
-    else
-        return 0
-    fi
+    log_request("GET", base, {}, {})
+    if args.dry:
+        return
 
-    # report error if jq parse error
-    jq . "$tmp_file"
+    try:
+        resp = requests.get(base, allow_redirects=False)
+    except requests.RequestException as e:
+        die(f"request failed: {e}")
+        return
 
-    # record history
-    manage_url=$(jq -r '.manageUrl' "$tmp_file")
-    manage_path=${manage_url##*/}
-    echo "$manage_path" >> "$hist_file"
+    if resp.status_code not in (200, 302):
+        die(f"{resp.status_code}: {resp.text}")
 
-    # copy URL to clipboard
-    url=$(jq -r '.url' "$tmp_file")
-    [ -n "$clip" ] && _clip "$url"
+    if args.meta:
+        try:
+            payload = resp.json()
+        except ValueError:
+            die(f"non-JSON response from /m/: {resp.text}")
+            return
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
 
-    return 0
-}
+    if args.output:
+        Path(args.output).write_bytes(resp.content)
+    else:
+        sys.stdout.buffer.write(resp.content)
 
-pb_update() {
-    # parse args
-    short_args="c:e:s:f:vhxd"
-    long_args="content:,expire:,passwd:,file:,verbose,clip,dry"
-    TEMP=$(getopt -o "$short_args" --long "$long_args" -n "$script_name" -- "$@") \
-        || return 1
-    eval set -- "$TEMP";
 
-    local name_passwd file content expire passwd verbose clip dry
-    while [[ ${1:0:1} == - ]]; do
-        [[ $1 == -- ]]             && { name_passwd="$2"; shift 2; break; };
-        [[ $1 =~ ^-f|--file$ ]]    && { file="$2"; shift 2; continue; };
-        [[ $1 =~ ^-c|--content$ ]] && { content="$2"; shift 2; continue; };
-        [[ $1 =~ ^-e|--expire$ ]]  && { expire="$2"; shift 2; continue; };
-        [[ $1 =~ ^-s|--passwd$ ]]  && { passwd="$2"; shift 2; continue; };
-        [[ $1 =~ ^-v|--verbose$ ]] && { verbose="true"; shift 1; continue; };
-        [[ $1 =~ ^-x|--clip$ ]]    && { clip="true"; shift 1; continue; };
-        [[ $1 =~ ^-d|--dry$ ]]     && { dry="true"; shift 1; continue; };
-        break;
-    done
-    [ "$#" -gt 0 ] && _die "redundant arguments '$*'"
+def cmd_delete(args: argparse.Namespace, domain: str) -> None:
+    name, passwd = parse_name_passwd(args.target)
+    if passwd is None:
+        passwd = lookup_passwd(name)
+    if not passwd:
+        die(
+            f"no passwd given, and cannot find passwd in history file '{history_path()}'"
+        )
 
-    # parse name and passwd
-    [ -z "$name_passwd" ] && _die "no name and passwd given"
-    name=${name_passwd%:*}
-    if [[ "$name_passwd" =~ : ]]; then
-        passwd=${name_passwd#*:}
-    else
-        name_passwd=$(grep "^$name:" "$hist_file" | tail -1) && [ -n "$name_passwd" ] && passwd=${name_passwd#*:}
-    fi
-    [ -z "$passwd" ] && _die "no passwd given, and cannot find passwd in history file '$hist_file'"
+    url = f"{domain}/{name}:{passwd}"
+    log_request("DELETE", f"{domain}/{name}:***", {}, {})
+    if args.dry:
+        return
 
-    # check arguments
-    [ -n "$content" ] && [ -n "$file" ] && _die "cannot set both 'content' and 'file'"
-    [ -n "$file" ] && [ ! -r "$file" ]  && _die "cannot read file '${file}'"
+    try:
+        resp = requests.delete(url)
+    except requests.RequestException as e:
+        die(f"request failed: {e}")
+        return
 
-    # build arguments
-    declare -a args=("curl_code" "-X" "PUT" "$domain/$name:$passwd")
-    [ -n "$file" ]    && args+=("-Fc=@$file")
-    [ -n "$content" ] && args+=("-Fc=\"$content\"")
-    [ -n "$expire" ]  && args+=("-Fe=\"$expire\"")
-    [ -n "$passwd" ]  && args+=("-Fs=\"$passwd\"")
-    [ -z "$content" ] && [ -z "$file" ] && args+=("-Fc=@-")
+    if resp.status_code != 200:
+        die(f"{resp.status_code}: {resp.text}")
 
-    # prepare curl
-    tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' EXIT
 
-    [ -n "$verbose" ] && _verbose "${args[@]}"
+def add_common(p: argparse.ArgumentParser) -> None:
+    p.add_argument("-v", "--verbose", action="store_true", help="verbose output")
+    p.add_argument(
+        "-d", "--dry", action="store_true", help="dry run, do not send the request"
+    )
 
-    # curl if not dry-run
-    if [ -z "$dry" ]; then
-        "${args[@]}" -o "$tmp_file" || _die "$status_code: $(cat "$tmp_file")"
-    else
-        return 0
-    fi
 
-    # report error if jq parse error
-    jq . "$tmp_file" 2>/dev/null || _die "$(cat "$tmp_file")"
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=SCRIPT_NAME,
+        description="pastebin-worker command-line client",
+    )
+    parser.add_argument(
+        "--base-url",
+        dest="base_url",
+        metavar="URL",
+        help=f"base URL of the pastebin instance (overrides $PB_DOMAIN, default: {DEFAULT_DOMAIN})",
+    )
+    sub = parser.add_subparsers(dest="action", required=True, metavar="ACTION")
 
-    # record history
-    manage_url=$(jq -r '.manageUrl' "$tmp_file")
-    manage_path=${manage_url##*/}
-    echo "$manage_path" >> "$hist_file"
+    p_post = sub.add_parser(
+        "post",
+        aliases=["p"],
+        help="upload a paste",
+        description="Upload a paste. If neither FILE nor -c/--content is given, "
+        "the paste content is read from stdin.",
+    )
+    p_post.add_argument("-c", "--content", help="inline content of the paste")
+    p_post.add_argument("-e", "--expire", help="expiration time (e.g. 60, 1h, 7d)")
+    p_post.add_argument("-n", "--name", help="custom name (prefix with ~)")
+    p_post.add_argument("-s", "--passwd", help="password")
+    p_post.add_argument(
+        "-p", "--private", action="store_true", help="use longer random name"
+    )
+    p_post.add_argument(
+        "-x", "--clip", action="store_true", help="copy URL to clipboard"
+    )
+    p_post.add_argument("-f", "--file", help="read paste from file")
+    p_post.add_argument(
+        "file_pos", nargs="?", metavar="FILE", help="read paste from file (positional)"
+    )
+    add_common(p_post)
+    p_post.set_defaults(func=cmd_post)
 
-    # copy URL to clipboard
-    url=$(jq -r '.url' "$tmp_file")
-    [ -n "$clip" ] && _clip "$url"
+    p_update = sub.add_parser(
+        "update",
+        aliases=["u"],
+        help="update an existing paste",
+        description="Update an existing paste. If neither -f/--file nor -c/--content "
+        "is given, the new content is read from stdin. If PASSWD is omitted, it is "
+        "looked up from the history file.",
+    )
+    p_update.add_argument("target", help="NAME[:PASSWD]")
+    p_update.add_argument("-c", "--content", help="inline content of the paste")
+    p_update.add_argument("-e", "--expire", help="expiration time")
+    p_update.add_argument("-s", "--passwd", help="password (overrides history lookup)")
+    p_update.add_argument("-f", "--file", help="read paste from file")
+    p_update.add_argument(
+        "-x", "--clip", action="store_true", help="copy URL to clipboard"
+    )
+    add_common(p_update)
+    p_update.set_defaults(func=cmd_update)
 
-    return 0
-}
+    p_get = sub.add_parser("get", aliases=["g"], help="fetch a paste")
+    p_get.add_argument("name", help="NAME[.EXT]")
+    p_get.add_argument("-o", "--output", help="write to FILE instead of stdout")
+    p_get.add_argument(
+        "-u", "--url", action="store_true", help="hit /u/ for 302 URL redirect"
+    )
+    p_get.add_argument(
+        "--meta", action="store_true", help="fetch /m/<name> metadata as pretty JSON"
+    )
+    add_common(p_get)
+    p_get.set_defaults(func=cmd_get)
 
-pb_get() {
-    # parse args
-    short_args="l:m:o::uvd"
-    long_args="lang:,mime:,output:,url,verbose,dry"
-    TEMP=$(getopt -o "$short_args" --long "$long_args" -n "$script_name" -- "$@") \
-        || return 1
-    eval set -- "$TEMP";
+    p_del = sub.add_parser("delete", aliases=["d"], help="delete a paste")
+    p_del.add_argument("target", help="NAME[:PASSWD]")
+    add_common(p_del)
+    p_del.set_defaults(func=cmd_delete)
 
-    local name lang mime output url verbose dry
-    while [[ ${1:0:1} == - ]]; do
-        [[ $1 == -- ]]             && { name="$2"; shift 2; break; };
-        [[ $1 =~ ^-l|--lang$ ]]    && { lang="$2"; shift 2; continue; };
-        [[ $1 =~ ^-m|--mime$ ]]    && { mime="$2"; shift 2; continue; };
-        [[ $1 =~ ^-o|--output$ ]]  && { output="$2"; shift 2; continue; };
-        [[ $1 =~ ^-u|--url$ ]]     && { url="true"; shift 1; continue; };
-        [[ $1 =~ ^-v|--verbose$ ]] && { verbose="true"; shift 1; continue; };
-        [[ $1 =~ ^-d|--dry$ ]]     && { dry="true"; shift 1; continue; };
-        break;
-    done
-    [ "$#" -gt 1 ] && _die "redundant arguments '$*'"
+    return parser
 
-    # check args
-    [ -z "$name" ] && _die "no paste name is given"
 
-    # build arguments
-    tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' EXIT
-    declare -a args=("curl_code" "-G")
-    [ -n "$url" ]     && args+=("$domain/u/$name") || args+=("$domain/$name")
-    [ -n "$lang" ]    && args+=("-d" "lang=$lang")
-    [ -n "$mime" ]    && args+=("-d" "mime=$mime")
-    [ -n "$output" ]  && args+=("-o" "$output") || args+=("-o" "$tmp_file")
+def main(argv: Optional[list] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    setup_logger(getattr(args, "verbose", False))
 
-    # prepare curl
-    [ -n "$verbose" ] && _verbose "${args[@]}"
+    domain = (args.base_url or os.environ.get("PB_DOMAIN") or DEFAULT_DOMAIN).rstrip(
+        "/"
+    )
+    args.func(args, domain)
 
-    # curl if not dry-run
-    if [ -z "$dry" ]; then
-        "${args[@]}" || _die "$status_code: $(cat "$tmp_file")"
-        [ -z "$output" ] && cat "$tmp_file"
-    else
-        return 0
-    fi
 
-    return 0
-}
-
-pb_delete() {
-    # parse args
-    short_args="vd"
-    long_args="verbose,dry"
-    TEMP=$(getopt -o "$short_args" --long "$long_args" -n "$script_name" -- "$@") \
-        || return 1
-    eval set -- "$TEMP";
-
-    local name_passwd verbose dry
-    while [[ ${1:0:1} == - ]]; do
-        [[ $1 == -- ]]             && { name_passwd="$2"; shift 2; break; };
-        [[ $1 =~ ^-v|--verbose$ ]] && { verbose="true"; shift 1; continue; };
-        [[ $1 =~ ^-d|--dry$ ]]     && { dry="true"; shift 1; continue; };
-        break;
-    done
-    [ "$#" -gt 0 ] && _die "redundant arguments '$*'"
-
-    # parse name and passwd
-    [ -z "$name_passwd" ] && _die "no name and passwd given"
-    name=${name_passwd%:*}
-    if [[ "$name_passwd" =~ : ]]; then
-        passwd=${name_passwd#*:}
-    else
-        name_passwd=$(grep "^$name:" "$hist_file" | tail -1) && [ -n "$name_passwd" ] && passwd=${name_passwd#*:}
-    fi
-    [ -z "$passwd" ] && _die "no passwd given, and cannot find passwd in history file '$hist_file'"
-
-    # build arguments
-    tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' EXIT
-    declare -a args=("curl_code" "-X" "DELETE" "$domain/$name:$passwd")
-
-    [ -n "$verbose" ] && _verbose "${args[@]}"
-
-    # curl if not dry-run
-    if [ -z "$dry" ]; then
-        "${args[@]}" -o "$tmp_file" || _die "$status_code: $(cat "$tmp_file")"
-    else
-        return 0
-    fi
-
-    return 0
-}
-
-main "$@"
+if __name__ == "__main__":
+    main()

--- a/scripts/pb.fish
+++ b/scripts/pb.fish
@@ -5,13 +5,11 @@ set -l commands p post u update g get d delete
 
 complete -c pb -f
 
-# common_args:
+# common args (accepted at any position: before or after the action)
 complete -c pb -s d -l dry -d 'dry run'
 complete -c pb -s v -l verbose -d 'verbose output'
-
-# root_args:
-complete -c pb -n "not __fish_seen_subcommand_from $commands" -s h -l help -d 'print help'
-complete -c pb -n "not __fish_seen_subcommand_from $commands" -l base-url -x -d 'Base URL (overrides $PB_DOMAIN)'
+complete -c pb -s h -l help -d 'print help'
+complete -c pb -l base-url -x -d 'Base URL (overrides $PB_DOMAIN)'
 
 # cmdlist:
 complete -c pb -n "not __fish_seen_subcommand_from $commands" -a post -d "Post paste"

--- a/scripts/pb.fish
+++ b/scripts/pb.fish
@@ -11,6 +11,7 @@ complete -c pb -s v -l verbose -d 'verbose output'
 
 # root_args:
 complete -c pb -n "not __fish_seen_subcommand_from $commands" -s h -l help -d 'print help'
+complete -c pb -n "not __fish_seen_subcommand_from $commands" -l base-url -x -d 'Base URL (overrides $PB_DOMAIN)'
 
 # cmdlist:
 complete -c pb -n "not __fish_seen_subcommand_from $commands" -a post -d "Post paste"
@@ -36,7 +37,13 @@ complete -c pb -n "__fish_seen_subcommand_from update u" -s s -l password -x -d 
 complete -c pb -n "__fish_seen_subcommand_from update u" -s x -l clip -f -d 'Clip the url to the clipboard'
 
 # case get:
-complete -c pb -n "__fish_seen_subcommand_from get g" -s l -l lang -x -d 'Highlight with language in a web page'
-complete -c pb -n "__fish_seen_subcommand_from get g" -s m -l mine -x -d 'Content of the paste'
+function __pb_hist_names
+    set -l hist_file (test -n "$XDG_CONFIG_DIR"; and echo "$XDG_CONFIG_DIR/pb_hist"; or echo "$HOME/.config/pb_hist")
+    test -r "$hist_file"; or return
+    # latest-first, dedup keeping the most recent occurrence
+    awk -F: 'NF { last[$1]=NR; name[NR]=$1 } END { for (i=NR; i>=1; i--) if (name[i] != "" && last[name[i]] == i) print name[i] }' "$hist_file"
+end
 complete -c pb -n "__fish_seen_subcommand_from get g" -s o -l output -r -d 'Output the paste in file'
 complete -c pb -n "__fish_seen_subcommand_from get g" -s u -l url -f -d 'Make a 302 redirection'
+complete -c pb -n "__fish_seen_subcommand_from get g" -l meta -f -d 'Fetch /m/<name> metadata as JSON'
+complete -c pb -n "__fish_seen_subcommand_from get g" -f -a '(__pb_hist_names)' -d 'paste from history'

--- a/shared/test/uploadPaste.spec.ts
+++ b/shared/test/uploadPaste.spec.ts
@@ -174,6 +174,9 @@ describe("uploadMPU", () => {
       if (url.includes("/mpu/complete")) {
         return Promise.resolve(jsonResp(complete))
       }
+      if (url.includes("/mpu/abort")) {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
       return Promise.reject(new Error(`unexpected fetch ${url}`))
     })
     vi.stubGlobal("fetch", fetchMock)
@@ -289,16 +292,17 @@ describe("uploadMPU", () => {
   })
 
   it("throws UploadError when a chunk upload returns non-ok", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>((input) => {
-        const url = input instanceof URL ? input.toString() : (input as string)
-        if (url.includes("/mpu/create")) {
-          return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
-        }
-        return Promise.reject(new Error(`unexpected fetch ${url}`))
-      }),
-    )
+    const fetchMock = vi.fn<typeof fetch>((input) => {
+      const url = input instanceof URL ? input.toString() : (input as string)
+      if (url.includes("/mpu/create")) {
+        return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
+      }
+      if (url.includes("/mpu/abort")) {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`))
+    })
+    vi.stubGlobal("fetch", fetchMock)
     setupXhr(() => ({ status: 500, body: "part failed" }))
 
     const err: unknown = await uploadMPU(API_URL, 4, {
@@ -308,6 +312,18 @@ describe("uploadMPU", () => {
 
     expect(err).toBeInstanceOf(UploadError)
     expect((err as UploadError).statusCode).toStrictEqual(500)
+
+    // Wait a microtask so the fire-and-forget abort fetch has a chance to land.
+    await new Promise((r) => setTimeout(r, 0))
+    const abortCall = fetchMock.mock.calls.find(([input]) => {
+      const url = input instanceof URL ? input.toString() : (input as string)
+      return url.includes("/mpu/abort")
+    })
+    expect(abortCall).toBeDefined()
+    const abortUrl = new URL(abortCall![0] instanceof URL ? abortCall![0].toString() : (abortCall![0] as string))
+    expect(abortUrl.searchParams.get("key")).toStrictEqual("k")
+    expect(abortUrl.searchParams.get("uploadId")).toStrictEqual("uid")
+    expect(abortCall![1]?.method).toStrictEqual("POST")
   })
 
   it("throws UploadError when complete returns non-ok", async () => {
@@ -320,6 +336,9 @@ describe("uploadMPU", () => {
         }
         if (url.includes("/mpu/complete")) {
           return Promise.resolve(new Response("complete failed", { status: 502 }))
+        }
+        if (url.includes("/mpu/abort")) {
+          return Promise.resolve(new Response(null, { status: 204 }))
         }
         return Promise.reject(new Error(`unexpected fetch ${url}`))
       }),

--- a/shared/test/uploadPaste.spec.ts
+++ b/shared/test/uploadPaste.spec.ts
@@ -15,9 +15,67 @@ function makeFile(size: number, name = "blob"): File {
   return new File([new Uint8Array(size)], name)
 }
 
+interface XhrCall {
+  method: string
+  url: string
+  body: BodyInit | null
+}
+
+class FakeXHR {
+  static respond: ((req: XhrCall) => { status: number; body: string }) | null = null
+  static calls: XhrCall[] = []
+
+  private _method = ""
+  private _url = ""
+  status = 0
+  responseText = ""
+
+  private _uploadListeners = new Map<string, ((e: ProgressEvent) => void)[]>()
+  upload = {
+    addEventListener: (type: string, cb: (e: ProgressEvent) => void) => {
+      const list = this._uploadListeners.get(type) ?? []
+      list.push(cb)
+      this._uploadListeners.set(type, list)
+    },
+  }
+
+  private _listeners = new Map<string, (() => void)[]>()
+
+  open(method: string, url: string) {
+    this._method = method
+    this._url = url
+  }
+
+  addEventListener(type: string, cb: () => void) {
+    const list = this._listeners.get(type) ?? []
+    list.push(cb)
+    this._listeners.set(type, list)
+  }
+
+  send(body: BodyInit | null) {
+    queueMicrotask(() => {
+      const call = { method: this._method, url: this._url, body }
+      FakeXHR.calls.push(call)
+      const resp = FakeXHR.respond!(call)
+      this.status = resp.status
+      this.responseText = resp.body
+      this._listeners.get("load")?.forEach((cb) => cb())
+    })
+  }
+}
+
+function setupXhr(respond: (req: XhrCall) => { status: number; body: string }): XhrCall[] {
+  FakeXHR.respond = respond
+  FakeXHR.calls = []
+  vi.stubGlobal("XMLHttpRequest", FakeXHR)
+  return FakeXHR.calls
+}
+
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  FakeXHR.respond = null
+  FakeXHR.calls = []
 })
 
 describe("UploadError", () => {
@@ -29,14 +87,12 @@ describe("UploadError", () => {
   })
 })
 
-type FetchCall = [input: string | URL, init: RequestInit]
-
 describe("uploadNormal", () => {
   it("POSTs to apiUrl on create and returns parsed json", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValue(jsonResp({ url: "https://example.com/abcd", manageUrl: "https://example.com/abcd:pw" }))
-    vi.stubGlobal("fetch", fetchMock)
+    const calls = setupXhr(() => ({
+      status: 200,
+      body: JSON.stringify({ url: "https://example.com/abcd", manageUrl: "https://example.com/abcd:pw" }),
+    }))
 
     const resp = await uploadNormal(API_URL, {
       content: makeFile(16, "x.txt"),
@@ -50,12 +106,11 @@ describe("uploadNormal", () => {
     })
 
     expect(resp.url).toStrictEqual("https://example.com/abcd")
-    expect(fetchMock).toHaveBeenCalledOnce()
-    const [target, init] = fetchMock.mock.calls[0] as FetchCall
-    expect(target).toStrictEqual(API_URL)
-    expect(init.method).toStrictEqual("POST")
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toStrictEqual(API_URL)
+    expect(calls[0].method).toStrictEqual("POST")
 
-    const fd = init.body as FormData
+    const fd = calls[0].body as FormData
     expect(fd.get("e")).toStrictEqual("10m")
     expect(fd.get("s")).toStrictEqual("pw")
     expect(fd.get("n")).toStrictEqual("abcd")
@@ -66,32 +121,29 @@ describe("uploadNormal", () => {
   })
 
   it("PUTs to manageUrl on update and skips name field", async () => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(jsonResp({ url: "u", manageUrl: "m" }))
-    vi.stubGlobal("fetch", fetchMock)
+    const calls = setupXhr(() => ({ status: 200, body: JSON.stringify({ url: "u", manageUrl: "m" }) }))
 
     await uploadNormal(API_URL, {
       content: makeFile(8),
       isUpdate: true,
       manageUrl: "https://example.com/abcd:pw",
-      name: "abcd", // should be ignored on update
+      name: "abcd",
     })
 
-    const [target, init] = fetchMock.mock.calls[0] as FetchCall
-    expect(target).toStrictEqual("https://example.com/abcd:pw")
-    expect(init.method).toStrictEqual("PUT")
-    expect((init.body as FormData).get("n")).toBeNull()
+    expect(calls[0].url).toStrictEqual("https://example.com/abcd:pw")
+    expect(calls[0].method).toStrictEqual("PUT")
+    expect((calls[0].body as FormData).get("n")).toBeNull()
   })
 
   it("throws TypeError when isUpdate without manageUrl", async () => {
-    const fetchMock = vi.fn<typeof fetch>()
-    vi.stubGlobal("fetch", fetchMock)
+    const calls = setupXhr(() => ({ status: 200, body: "{}" }))
 
     await expect(uploadNormal(API_URL, { content: makeFile(8), isUpdate: true })).rejects.toBeInstanceOf(TypeError)
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(calls).toHaveLength(0)
   })
 
   it("throws UploadError carrying statusCode on non-ok response", async () => {
-    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response("bad name", { status: 400 })))
+    setupXhr(() => ({ status: 400, body: "bad name" }))
 
     const err: unknown = await uploadNormal(API_URL, {
       content: makeFile(8),
@@ -106,32 +158,38 @@ describe("uploadNormal", () => {
 
 describe("uploadMPU", () => {
   function setupHappyPath(numParts: number, complete = { url: "u", manageUrl: "m" }) {
-    const calls: { url: string; method: string; body?: BodyInit | null }[] = []
+    const fetchCalls: { url: string; method: string; body?: BodyInit | null }[] = []
     const partResponses: R2UploadedPart[] = Array.from({ length: numParts }, (_, i) => ({
       partNumber: i + 1,
       etag: `etag${i + 1}`,
     }))
     let partIdx = 0
+
     const fetchMock = vi.fn<typeof fetch>((input, init = {}) => {
       const url = input instanceof URL ? input.toString() : (input as string)
-      calls.push({ url, method: init.method || "GET", body: init.body as BodyInit | null })
+      fetchCalls.push({ url, method: init.method || "GET", body: init.body as BodyInit | null })
       if (url.includes("/mpu/create")) {
         return Promise.resolve(jsonResp({ name: "~abcd", key: "k", uploadId: "uid" }))
-      }
-      if (url.includes("/mpu/resume")) {
-        return Promise.resolve(jsonResp(partResponses[partIdx++]))
       }
       if (url.includes("/mpu/complete")) {
         return Promise.resolve(jsonResp(complete))
       }
-      return Promise.reject(new Error(`unexpected url ${url}`))
+      return Promise.reject(new Error(`unexpected fetch ${url}`))
     })
     vi.stubGlobal("fetch", fetchMock)
-    return { calls, fetchMock }
+
+    const xhrCalls = setupXhr((call) => {
+      if (call.url.includes("/mpu/resume")) {
+        return { status: 200, body: JSON.stringify(partResponses[partIdx++]) }
+      }
+      throw new Error(`unexpected xhr ${call.url}`)
+    })
+
+    return { fetchCalls, xhrCalls, fetchMock }
   }
 
   it("uploads in chunks, calls progress callback, and forwards optional fields on complete", async () => {
-    const { calls } = setupHappyPath(3)
+    const { fetchCalls, xhrCalls } = setupHappyPath(3)
 
     const progress = vi.fn()
     await uploadMPU(
@@ -150,27 +208,30 @@ describe("uploadMPU", () => {
       progress,
     )
 
-    expect(progress).toHaveBeenCalledTimes(3)
-    expect(progress.mock.calls[0]).toEqual([4, 10])
-    expect(progress.mock.calls[1]).toEqual([8, 10])
-    expect(progress.mock.calls[2]).toEqual([10, 10])
+    // final progress reports full size
+    expect(progress).toHaveBeenLastCalledWith(10, 10)
+    // each cumulative checkpoint appears at some point
+    const progressValues = progress.mock.calls.map((c) => c[0] as number)
+    expect(progressValues).toContain(4)
+    expect(progressValues).toContain(8)
+    expect(progressValues).toContain(10)
 
-    const create = calls[0]
+    const create = fetchCalls[0]
     expect(create.method).toStrictEqual("POST")
     expect(create.url).toContain("/mpu/create")
     expect(create.url).toContain("n=abcd")
     expect(create.url).toContain("p=1")
     expect(create.url).toContain("e=1d")
 
-    expect(calls[1].method).toStrictEqual("PUT")
-    expect(calls[1].url).toContain("/mpu/resume")
-    expect(calls[1].url).toContain("partNumber=1")
-    expect(calls[3].url).toContain("partNumber=3")
+    const resumeCalls = xhrCalls.filter((c) => c.url.includes("/mpu/resume"))
+    expect(resumeCalls).toHaveLength(3)
+    expect(resumeCalls.every((c) => c.method === "PUT")).toBe(true)
+    const partNumbers = resumeCalls.map((c) => new URL(c.url).searchParams.get("partNumber")).sort()
+    expect(partNumbers).toEqual(["1", "2", "3"])
 
-    const complete = calls[4]
-    expect(complete.url).toContain("/mpu/complete")
-    expect(complete.method).toStrictEqual("POST")
-    const fd = complete.body as FormData
+    const completeReq = fetchCalls.find((c) => c.url.includes("/mpu/complete"))!
+    expect(completeReq.method).toStrictEqual("POST")
+    const fd = completeReq.body as FormData
     expect(fd.get("e")).toStrictEqual("1d")
     expect(fd.get("s")).toStrictEqual("pw")
     expect(fd.get("lang")).toStrictEqual("rust")
@@ -178,7 +239,7 @@ describe("uploadMPU", () => {
   })
 
   it("uses create-update endpoint and PUT on update with manageUrl password", async () => {
-    const { calls } = setupHappyPath(1)
+    const { fetchCalls } = setupHappyPath(1)
 
     await uploadMPU(API_URL, 16, {
       content: makeFile(4),
@@ -186,11 +247,11 @@ describe("uploadMPU", () => {
       manageUrl: "https://example.com/abcd:secretpw",
     })
 
-    expect(calls[0].url).toContain("/mpu/create-update")
-    expect(calls[0].url).toContain("name=abcd")
-    expect(calls[0].url).toContain("password=secretpw")
-    expect(calls[2].method).toStrictEqual("PUT")
-    expect(calls[2].url).toContain("/mpu/complete")
+    expect(fetchCalls[0].url).toContain("/mpu/create-update")
+    expect(fetchCalls[0].url).toContain("name=abcd")
+    expect(fetchCalls[0].url).toContain("password=secretpw")
+    const completeCall = fetchCalls.find((c) => c.url.includes("/mpu/complete"))!
+    expect(completeCall.method).toStrictEqual("PUT")
   })
 
   it("throws TypeError when isUpdate without manageUrl", async () => {
@@ -228,15 +289,17 @@ describe("uploadMPU", () => {
   })
 
   it("throws UploadError when a chunk upload returns non-ok", async () => {
-    let call = 0
     vi.stubGlobal(
       "fetch",
-      vi.fn<typeof fetch>(() => {
-        call++
-        if (call === 1) return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
-        return Promise.resolve(new Response("part failed", { status: 500 }))
+      vi.fn<typeof fetch>((input) => {
+        const url = input instanceof URL ? input.toString() : (input as string)
+        if (url.includes("/mpu/create")) {
+          return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
+        }
+        return Promise.reject(new Error(`unexpected fetch ${url}`))
       }),
     )
+    setupXhr(() => ({ status: 500, body: "part failed" }))
 
     const err: unknown = await uploadMPU(API_URL, 4, {
       content: makeFile(8),
@@ -248,16 +311,20 @@ describe("uploadMPU", () => {
   })
 
   it("throws UploadError when complete returns non-ok", async () => {
-    let call = 0
     vi.stubGlobal(
       "fetch",
-      vi.fn<typeof fetch>(() => {
-        call++
-        if (call === 1) return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
-        if (call === 2) return Promise.resolve(jsonResp({ partNumber: 1, etag: "e" }))
-        return Promise.resolve(new Response("complete failed", { status: 502 }))
+      vi.fn<typeof fetch>((input) => {
+        const url = input instanceof URL ? input.toString() : (input as string)
+        if (url.includes("/mpu/create")) {
+          return Promise.resolve(jsonResp({ name: "~a", key: "k", uploadId: "uid" }))
+        }
+        if (url.includes("/mpu/complete")) {
+          return Promise.resolve(new Response("complete failed", { status: 502 }))
+        }
+        return Promise.reject(new Error(`unexpected fetch ${url}`))
       }),
     )
+    setupXhr(() => ({ status: 200, body: JSON.stringify({ partNumber: 1, etag: "e" }) }))
 
     const err: unknown = await uploadMPU(API_URL, 8, {
       content: makeFile(4),

--- a/shared/uploadPaste.ts
+++ b/shared/uploadPaste.ts
@@ -29,6 +29,97 @@ export interface UploadOptions {
   manageUrl?: string
 }
 
+export const DEFAULT_MPU_CONCURRENCY = 8
+
+interface XhrSendOptions {
+  method: "POST" | "PUT"
+  body: XMLHttpRequestBodyInit
+  onUploadProgress?: (loaded: number, total: number) => void
+  signal?: AbortSignal
+}
+
+interface XhrResponse {
+  ok: boolean
+  status: number
+  text(): Promise<string>
+  json<T = unknown>(): Promise<T>
+}
+
+function xhrSend(url: string | URL, opts: XhrSendOptions): Promise<XhrResponse> {
+  // Fallback for non-browser environments (Workers/Node tests): use fetch, no upload progress events.
+  if (typeof XMLHttpRequest === "undefined") {
+    return fetch(url.toString(), { method: opts.method, body: opts.body, signal: opts.signal }).then((r) => ({
+      ok: r.ok,
+      status: r.status,
+      text: () => r.text(),
+      json: <T = unknown>() => r.json() as T,
+    }))
+  }
+  return new Promise((resolve, reject) => {
+    if (opts.signal?.aborted) {
+      reject(new DOMException("aborted", "AbortError"))
+      return
+    }
+    const xhr = new XMLHttpRequest()
+    xhr.open(opts.method, url.toString())
+    if (opts.onUploadProgress) {
+      xhr.upload.addEventListener("progress", (e) => {
+        if (e.lengthComputable) opts.onUploadProgress!(e.loaded, e.total)
+      })
+    }
+    const onAbort = () => xhr.abort()
+    opts.signal?.addEventListener("abort", onAbort, { once: true })
+    xhr.addEventListener("load", () => {
+      opts.signal?.removeEventListener("abort", onAbort)
+      const body = xhr.responseText
+      resolve({
+        ok: xhr.status >= 200 && xhr.status < 300,
+        status: xhr.status,
+        text: () => Promise.resolve(body),
+        json: <T>() => Promise.resolve(JSON.parse(body) as T),
+      })
+    })
+    xhr.addEventListener("abort", () => {
+      opts.signal?.removeEventListener("abort", onAbort)
+      reject(new DOMException("aborted", "AbortError"))
+    })
+    xhr.addEventListener("error", () => {
+      opts.signal?.removeEventListener("abort", onAbort)
+      reject(new UploadError(0, "network error"))
+    })
+    xhr.addEventListener("timeout", () => {
+      opts.signal?.removeEventListener("abort", onAbort)
+      reject(new UploadError(0, "timeout"))
+    })
+    xhr.send(opts.body)
+  })
+}
+
+async function runWithConcurrency<T>(
+  count: number,
+  limit: number,
+  worker: (index: number) => Promise<T>,
+): Promise<T[]> {
+  const results = new Array<T>(count)
+  let next = 0
+  let aborted = false
+  async function run() {
+    while (!aborted) {
+      const i = next++
+      if (i >= count) return
+      try {
+        results[i] = await worker(i)
+      } catch (e) {
+        aborted = true
+        throw e
+      }
+    }
+  }
+  const runners = Array.from({ length: Math.min(limit, count) }, () => run())
+  await Promise.all(runners)
+  return results
+}
+
 // note that apiUrl should be manageUrl when isUpload
 export async function uploadNormal(
   apiUrl: string,
@@ -43,6 +134,8 @@ export async function uploadNormal(
     expire,
     manageUrl,
   }: UploadOptions,
+  progressCallback?: (doneBytes: number, allBytes: number) => void,
+  signal?: AbortSignal,
 ): Promise<PasteResponse> {
   const fd = new FormData()
 
@@ -60,21 +153,20 @@ export async function uploadNormal(
   if (highlightLanguage !== undefined) fd.set("lang", highlightLanguage)
   if (isPrivate) fd.set("p", "1")
 
-  const resp = isUpdate
-    ? await fetch(manageUrl!, {
-        method: "PUT",
-        body: fd,
-      })
-    : await fetch(apiUrl, {
-        method: "POST",
-        body: fd,
-      })
+  const resp = await xhrSend(isUpdate ? manageUrl! : apiUrl, {
+    method: isUpdate ? "PUT" : "POST",
+    body: fd,
+    onUploadProgress: progressCallback
+      ? (loaded) => progressCallback(Math.min(loaded, content.size), content.size)
+      : undefined,
+    signal,
+  })
 
   if (!resp.ok) {
     throw new UploadError(resp.status, await resp.text())
   }
 
-  return await resp.json()
+  return await resp.json<PasteResponse>()
 }
 
 export async function uploadMPU(
@@ -92,84 +184,118 @@ export async function uploadMPU(
     manageUrl,
   }: UploadOptions,
   progressCallback?: (doneBytes: number, allBytes: number) => void,
-) {
-  const createReqUrl = isUpdate ? new URL(`${apiUrl}/mpu/create-update`) : new URL(`${apiUrl}/mpu/create`)
-  if (!isUpdate) {
-    if (name !== undefined) {
-      createReqUrl.searchParams.set("n", name)
-    }
-    if (isPrivate) {
-      createReqUrl.searchParams.set("p", "1")
-    }
-  } else {
-    if (manageUrl === undefined) {
-      throw TypeError("uploadMPU: no manageUrl specified in update")
-    }
-    const { name: nameFromUrl, password: passwordFromUrl } = parsePath(new URL(manageUrl).pathname)
-    if (passwordFromUrl === undefined) {
-      throw TypeError("uploadMPU: password not specified in manageUrl")
-    }
-    createReqUrl.searchParams.set("name", nameFromUrl)
-    createReqUrl.searchParams.set("password", passwordFromUrl)
-  }
-  if (expire !== undefined) {
-    createReqUrl.searchParams.set("e", expire)
+  concurrency: number = DEFAULT_MPU_CONCURRENCY,
+  signal?: AbortSignal,
+): Promise<PasteResponse> {
+  // Internal controller: cancels all in-flight subrequests when one chunk fails or external signal aborts.
+  const ctrl = new AbortController()
+  const onExternalAbort = () => ctrl.abort()
+  if (signal) {
+    if (signal.aborted) ctrl.abort()
+    else signal.addEventListener("abort", onExternalAbort, { once: true })
   }
 
-  const createReqResp = await fetch(createReqUrl, { method: "POST" })
-  if (!createReqResp.ok) {
-    throw new UploadError(createReqResp.status, await createReqResp.text())
+  try {
+    return await doMPU()
+  } catch (e) {
+    ctrl.abort()
+    throw e
+  } finally {
+    signal?.removeEventListener("abort", onExternalAbort)
   }
-  const createResp: MPUCreateResponse = await createReqResp.json()
 
-  const numParts = Math.ceil(content.size / chunkSize)
-
-  // TODO: parallelize
-  const uploadedParts: R2UploadedPart[] = []
-  let uploadedBytes = 0
-  for (let i = 0; i < numParts; i++) {
-    const resumeUrl = new URL(`${apiUrl}/mpu/resume`)
-    resumeUrl.searchParams.set("key", createResp.key)
-    resumeUrl.searchParams.set("uploadId", createResp.uploadId)
-    resumeUrl.searchParams.set("partNumber", (i + 1).toString()) // because partNumber need to nonzero
-    const chunk = content.slice(i * chunkSize, (i + 1) * chunkSize)
-    const resumeReqResp = await fetch(resumeUrl, { method: "PUT", body: chunk })
-    if (!resumeReqResp.ok) {
-      throw new UploadError(resumeReqResp.status, await resumeReqResp.text())
+  async function doMPU(): Promise<PasteResponse> {
+    const createReqUrl = isUpdate ? new URL(`${apiUrl}/mpu/create-update`) : new URL(`${apiUrl}/mpu/create`)
+    if (!isUpdate) {
+      if (name !== undefined) {
+        createReqUrl.searchParams.set("n", name)
+      }
+      if (isPrivate) {
+        createReqUrl.searchParams.set("p", "1")
+      }
+    } else {
+      if (manageUrl === undefined) {
+        throw TypeError("uploadMPU: no manageUrl specified in update")
+      }
+      const { name: nameFromUrl, password: passwordFromUrl } = parsePath(new URL(manageUrl).pathname)
+      if (passwordFromUrl === undefined) {
+        throw TypeError("uploadMPU: password not specified in manageUrl")
+      }
+      createReqUrl.searchParams.set("name", nameFromUrl)
+      createReqUrl.searchParams.set("password", passwordFromUrl)
     }
-    const resumeResp: R2UploadedPart = await resumeReqResp.json()
-    uploadedParts.push(resumeResp)
-    uploadedBytes += chunk.size
-    if (progressCallback) {
-      progressCallback(uploadedBytes, content.size)
+    if (expire !== undefined) {
+      createReqUrl.searchParams.set("e", expire)
     }
-  }
 
-  const completeFormData = new FormData()
-  const completeUrl = new URL(`${apiUrl}/mpu/complete`)
-  completeUrl.searchParams.set("name", createResp.name)
-  completeUrl.searchParams.set("key", createResp.key)
-  completeUrl.searchParams.set("uploadId", createResp.uploadId)
-  completeFormData.set("c", new File([JSON.stringify(uploadedParts)], content.name))
-  if (expire !== undefined) {
-    completeFormData.set("e", expire)
+    const createReqResp = await fetch(createReqUrl, { method: "POST", signal: ctrl.signal })
+    if (!createReqResp.ok) {
+      throw new UploadError(createReqResp.status, await createReqResp.text())
+    }
+    const createResp: MPUCreateResponse = await createReqResp.json()
+
+    const numParts = Math.ceil(content.size / chunkSize)
+
+    const chunkLoaded = new Array<number>(numParts).fill(0)
+    const reportProgress = progressCallback
+      ? () =>
+          progressCallback(
+            chunkLoaded.reduce((a, b) => a + b, 0),
+            content.size,
+          )
+      : undefined
+    const uploadedParts = await runWithConcurrency(numParts, concurrency, async (i) => {
+      const resumeUrl = new URL(`${apiUrl}/mpu/resume`)
+      resumeUrl.searchParams.set("key", createResp.key)
+      resumeUrl.searchParams.set("uploadId", createResp.uploadId)
+      resumeUrl.searchParams.set("partNumber", (i + 1).toString()) // because partNumber need to nonzero
+      const chunk = content.slice(i * chunkSize, (i + 1) * chunkSize)
+      const resumeReqResp = await xhrSend(resumeUrl, {
+        method: "PUT",
+        body: chunk,
+        onUploadProgress: reportProgress
+          ? (loaded) => {
+              chunkLoaded[i] = Math.min(loaded, chunk.size)
+              reportProgress()
+            }
+          : undefined,
+        signal: ctrl.signal,
+      })
+      if (!resumeReqResp.ok) {
+        throw new UploadError(resumeReqResp.status, await resumeReqResp.text())
+      }
+      chunkLoaded[i] = chunk.size
+      reportProgress?.()
+      return await resumeReqResp.json<R2UploadedPart>()
+    })
+
+    const completeFormData = new FormData()
+    const completeUrl = new URL(`${apiUrl}/mpu/complete`)
+    completeUrl.searchParams.set("name", createResp.name)
+    completeUrl.searchParams.set("key", createResp.key)
+    completeUrl.searchParams.set("uploadId", createResp.uploadId)
+    completeFormData.set("c", new File([JSON.stringify(uploadedParts)], content.name))
+    if (expire !== undefined) {
+      completeFormData.set("e", expire)
+    }
+    if (password !== undefined) {
+      completeFormData.set("s", password)
+    }
+    if (highlightLanguage !== undefined) {
+      completeFormData.set("lang", highlightLanguage)
+    }
+    if (encryptionScheme !== undefined) {
+      completeFormData.set("encryption-scheme", encryptionScheme)
+    }
+    const completeReqResp = await fetch(completeUrl, {
+      method: isUpdate ? "PUT" : "POST",
+      body: completeFormData,
+      signal: ctrl.signal,
+    })
+    if (!completeReqResp.ok) {
+      throw new UploadError(completeReqResp.status, await completeReqResp.text())
+    }
+    const completeResp: PasteResponse = await completeReqResp.json()
+    return completeResp
   }
-  if (password !== undefined) {
-    completeFormData.set("s", password)
-  }
-  if (highlightLanguage !== undefined) {
-    completeFormData.set("lang", highlightLanguage)
-  }
-  if (encryptionScheme !== undefined) {
-    completeFormData.set("encryption-scheme", encryptionScheme)
-  }
-  const completeReqResp = await fetch(completeUrl, {
-    method: isUpdate ? "PUT" : "POST",
-    body: completeFormData,
-  })
-  if (!completeReqResp.ok) {
-    throw new UploadError(completeReqResp.status, await completeReqResp.text())
-  }
-  const completeResp: PasteResponse = await completeReqResp.json()
-  return completeResp
 }

--- a/shared/uploadPaste.ts
+++ b/shared/uploadPaste.ts
@@ -195,10 +195,22 @@ export async function uploadMPU(
     else signal.addEventListener("abort", onExternalAbort, { once: true })
   }
 
+  // Captured once /mpu/create succeeds; used by the catch to release R2-side parts.
+  let createResp: MPUCreateResponse | undefined
+
   try {
     return await doMPU()
   } catch (e) {
     ctrl.abort()
+    if (createResp) {
+      const abortUrl = new URL(`${apiUrl}/mpu/abort`)
+      abortUrl.searchParams.set("key", createResp.key)
+      abortUrl.searchParams.set("uploadId", createResp.uploadId)
+      // Fire-and-forget: must outlive the cancellation that triggered us, no signal/progress.
+      void fetch(abortUrl, { method: "POST" }).catch(() => {
+        /* swallow: orphaned R2 parts are a soft failure */
+      })
+    }
     throw e
   } finally {
     signal?.removeEventListener("abort", onExternalAbort)
@@ -232,7 +244,9 @@ export async function uploadMPU(
     if (!createReqResp.ok) {
       throw new UploadError(createReqResp.status, await createReqResp.text())
     }
-    const createResp: MPUCreateResponse = await createReqResp.json()
+    const parsedCreateResp: MPUCreateResponse = await createReqResp.json()
+    createResp = parsedCreateResp
+    const { key: createKey, uploadId: createUploadId, name: createName } = parsedCreateResp
 
     const numParts = Math.ceil(content.size / chunkSize)
 
@@ -246,8 +260,8 @@ export async function uploadMPU(
       : undefined
     const uploadedParts = await runWithConcurrency(numParts, concurrency, async (i) => {
       const resumeUrl = new URL(`${apiUrl}/mpu/resume`)
-      resumeUrl.searchParams.set("key", createResp.key)
-      resumeUrl.searchParams.set("uploadId", createResp.uploadId)
+      resumeUrl.searchParams.set("key", createKey)
+      resumeUrl.searchParams.set("uploadId", createUploadId)
       resumeUrl.searchParams.set("partNumber", (i + 1).toString()) // because partNumber need to nonzero
       const chunk = content.slice(i * chunkSize, (i + 1) * chunkSize)
       const resumeReqResp = await xhrSend(resumeUrl, {
@@ -271,9 +285,9 @@ export async function uploadMPU(
 
     const completeFormData = new FormData()
     const completeUrl = new URL(`${apiUrl}/mpu/complete`)
-    completeUrl.searchParams.set("name", createResp.name)
-    completeUrl.searchParams.set("key", createResp.key)
-    completeUrl.searchParams.set("uploadId", createResp.uploadId)
+    completeUrl.searchParams.set("name", createName)
+    completeUrl.searchParams.set("key", createKey)
+    completeUrl.searchParams.set("uploadId", createUploadId)
     completeFormData.set("c", new File([JSON.stringify(uploadedParts)], content.name))
     if (expire !== undefined) {
       completeFormData.set("e", expire)

--- a/worker/handlers/handleMPU.ts
+++ b/worker/handlers/handleMPU.ts
@@ -115,7 +115,7 @@ export async function handleMPUComplete(request: Request, env: Env, completeBody
   const object = await multipartUpload.complete(completeBody)
   if (object.size > parseSize(env.R2_MAX_ALLOWED)!) {
     await env.R2.delete(object.key)
-    throw new WorkerError(413, `payload too large (max ${parseSize(env.R2_MAX_ALLOWED)!} bytes allowed)`)
+    throw new WorkerError(413, `payload too large (max ${env.R2_MAX_ALLOWED} allowed)`)
   }
   return object
 }

--- a/worker/handlers/handleMPU.ts
+++ b/worker/handlers/handleMPU.ts
@@ -90,8 +90,37 @@ export async function handleMPUResume(request: Request, env: Env): Promise<Respo
 
   const partNumber = parseInt(partNumberString)
   const multipartUpload = env.R2.resumeMultipartUpload(key, uploadId)
-  const uploadedPart: R2UploadedPart = await multipartUpload.uploadPart(partNumber, request.body)
+  let uploadedPart: R2UploadedPart
+  try {
+    uploadedPart = await multipartUpload.uploadPart(partNumber, request.body)
+  } catch (e) {
+    // Most commonly: uploadId has been aborted, completed, or expired. R2 may also
+    // throw transient service errors here, but those are rare enough that lumping
+    // them as 410 is acceptable — the client retries from /mpu/create either way.
+    console.warn(`MPU resume failed for key=${key}, uploadId=${uploadId}, part=${partNumber}: ${String(e)}`)
+    throw new WorkerError(410, "multipart upload no longer exists; please retry from /mpu/create")
+  }
   return new Response(JSON.stringify(uploadedPart))
+}
+
+// POST /mpu/abort?key=<key>&uploadId=<uploadId>
+// Releases R2-side multipart state for an upload that won't be completed.
+// Knowing key + uploadId is the auth: both are returned from /mpu/create
+// to whoever initiated the upload and aren't stored elsewhere.
+// Idempotent: an unknown / already-aborted / completed uploadId still returns 204.
+export async function handleMPUAbort(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url)
+  const uploadId = url.searchParams.get("uploadId")
+  const key = url.searchParams.get("key")
+  if (uploadId === null || key === null) {
+    throw new WorkerError(400, "missing uploadId or key in searchParams")
+  }
+  try {
+    await env.R2.resumeMultipartUpload(key, uploadId).abort()
+  } catch (e) {
+    console.warn(`MPU abort failed for key=${key}, uploadId=${uploadId}: ${String(e)}`)
+  }
+  return new Response(null, { status: 204 })
 }
 
 // POST /mpu/complete?name=<name>&key=<key>&uploadId=<uploadId>
@@ -112,9 +141,20 @@ export async function handleMPUComplete(request: Request, env: Env, completeBody
     throw new WorkerError(400, `name ‘${name}’ is not consistent with the originally specified name`)
   }
 
-  const object = await multipartUpload.complete(completeBody)
+  let object: R2Object
+  try {
+    object = await multipartUpload.complete(completeBody)
+  } catch (e) {
+    console.warn(`MPU complete failed for key=${key}, uploadId=${uploadId}: ${String(e)}`)
+    throw new WorkerError(410, "multipart upload no longer exists; please retry from /mpu/create")
+  }
   if (object.size > parseSize(env.R2_MAX_ALLOWED)!) {
-    await env.R2.delete(object.key)
+    // Best-effort cleanup; if delete fails we still want the 413 to reach the user.
+    try {
+      await env.R2.delete(object.key)
+    } catch (e) {
+      console.warn(`failed to delete oversized MPU object '${object.key}': ${String(e)}`)
+    }
     throw new WorkerError(413, `payload too large (max ${env.R2_MAX_ALLOWED} allowed)`)
   }
   return object

--- a/worker/handlers/handleWrite.ts
+++ b/worker/handlers/handleWrite.ts
@@ -6,7 +6,13 @@ import { parsePath, parseSize, parseExpiration } from "../../shared/parsers.js"
 import { verifyName, verifyPassword } from "../../shared/verify.js"
 import type { PasteResponse } from "../../shared/interfaces.js"
 import { MaxFileSizeExceededError, MultipartParseError, parseMultipartRequest } from "@mjackson/multipart-parser"
-import { handleMPUComplete, handleMPUCreate, handleMPUCreateUpdate, handleMPUResume } from "./handleMPU.js"
+import {
+  handleMPUAbort,
+  handleMPUComplete,
+  handleMPUCreate,
+  handleMPUCreateUpdate,
+  handleMPUResume,
+} from "./handleMPU.js"
 
 interface ParsedMultipartPart {
   filename?: string
@@ -75,6 +81,8 @@ export async function handlePostOrPut(
     return await handleMPUCreateUpdate(request, env)
   } else if (url.pathname === "/mpu/resume" && isPut) {
     return await handleMPUResume(request, env)
+  } else if (url.pathname === "/mpu/abort" && !isPut) {
+    return await handleMPUAbort(request, env)
   } else if (url.pathname === "/mpu/complete") {
     isMPUComplete = true // we will handle mpu complete later since it is uploaded with formdata
   } else if (url.pathname.startsWith("/mpu/")) {

--- a/worker/handlers/handleWrite.ts
+++ b/worker/handlers/handleWrite.ts
@@ -15,10 +15,10 @@ interface ParsedMultipartPart {
   contentLength: number
 }
 
-async function multipartToMap(req: Request, sizeLimit: number): Promise<Map<string, ParsedMultipartPart>> {
+async function multipartToMap(req: Request, sizeLimit: string): Promise<Map<string, ParsedMultipartPart>> {
   const partsMap = new Map<string, ParsedMultipartPart>()
   try {
-    for await (const part of parseMultipartRequest(req, { maxFileSize: sizeLimit })) {
+    for await (const part of parseMultipartRequest(req, { maxFileSize: parseSize(sizeLimit)! })) {
       if (part.name) {
         if (part.isFile) {
           const arrayBuffer = part.arrayBuffer
@@ -41,7 +41,7 @@ async function multipartToMap(req: Request, sizeLimit: number): Promise<Map<stri
     }
   } catch (err) {
     if (err instanceof MaxFileSizeExceededError) {
-      throw new WorkerError(413, `payload too large (max ${sizeLimit} bytes allowed)`)
+      throw new WorkerError(413, `payload too large (max ${sizeLimit} allowed)`)
     } else if (err instanceof MultipartParseError) {
       console.warn("Failed to parse multipart request:", err.message)
       throw new WorkerError(400, "Failed to parse multipart request")
@@ -88,7 +88,7 @@ export async function handlePostOrPut(
     throw new WorkerError(400, `bad usage, please use 'multipart/form-data' instead of ${contentType}`)
   }
 
-  const parts = await multipartToMap(request, parseSize(env.R2_MAX_ALLOWED)!)
+  const parts = await multipartToMap(request, env.R2_MAX_ALLOWED)
 
   if (!parts.has("c")) {
     throw new WorkerError(400, "cannot find content in formdata")
@@ -147,7 +147,7 @@ export async function handlePostOrPut(
   if (isPut) {
     let pasteName: string | undefined
     let password: string | undefined
-    // if isMPCComplete, we cannot parse path
+    // if isMPUComplete, we cannot parse path
     if (!isMPUComplete) {
       const parsed = parsePath(url.pathname)
       if (parsed.password === undefined) {

--- a/worker/test/mpuErrors.spec.ts
+++ b/worker/test/mpuErrors.spec.ts
@@ -96,6 +96,26 @@ describe("MPU error paths", () => {
     expect(await resp.text()).toContain("not consistent")
   })
 
+  it("handleMPUResume returns 410 when uploadId no longer exists", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/resume?key=nonexistent&uploadId=missinguploadid&partNumber=1`, {
+        method: "PUT",
+        body: new Uint8Array(8),
+      }),
+    )
+    expect(resp.status).toStrictEqual(410)
+    expect(await resp.text()).toContain("no longer exists")
+  })
+
+  it("handleMPUAbort is idempotent for an unknown uploadId", async () => {
+    const resp = await workerFetch(
+      ctx,
+      new Request(`${BASE_URL}/mpu/abort?key=nonexistent&uploadId=missinguploadid`, { method: "POST" }),
+    )
+    expect(resp.status).toStrictEqual(204)
+  })
+
   it("handleMPUComplete returns 413 when uploaded object exceeds R2_MAX_ALLOWED", async () => {
     const tightEnv = { ...env, R2_MAX_ALLOWED: "1K" }
 


### PR DESCRIPTION
- **refactor(scripts): rewrite pb in Python with requests**
- **feat(scripts): add MPU support to pb with progress bar, plus polish**
- **feat(upload): parallel MPU, byte-level progress, cancel button**
- **feat(mpu): /mpu/abort endpoint with cleanup wiring**
- **chore: ignore .gitignore**
