### PR TITLE
Fix valid UTF-8 text rendering when chardet guesses legacy encoding

### DIFF
--- a/frontend/pages/DisplayPaste.tsx
+++ b/frontend/pages/DisplayPaste.tsx
@@ -13,6 +13,16 @@ import "../styles/highlight-theme-dark.css"
 
 const utf8CompatibleEncodings = ["UTF-8", "ASCII", "ISO-8859-1"]
 
+function detectEncoding(content: ArrayBuffer | Uint8Array): string | null {
+  const bytes = content instanceof Uint8Array ? content : new Uint8Array(content)
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    return "UTF-8"
+  } catch {
+    return chardet.detect(bytes)
+  }
+}
+
 export function DisplayPaste({ config }: { config: Env }) {
   const [pasteFile, setPasteFile] = useState<File | undefined>(undefined)
   const [pasteContentBuffer, setPasteContentBuffer] = useState<Uint8Array | undefined>(undefined)
@@ -72,7 +82,7 @@ export function DisplayPaste({ config }: { config: Env }) {
           setDecrypted("encrypted")
           setFileBinary(true)
         } else {
-          const encoding = chardet.detect(respBytes)
+          const encoding = detectEncoding(respBytes)
           setFileBinary(encoding === null || !utf8CompatibleEncodings.includes(encoding))
           setGuessedEncoding(encoding)
         }
@@ -95,7 +105,7 @@ export function DisplayPaste({ config }: { config: Env }) {
         }
         setPasteFile(new File([decrypted as BlobPart], inferredFilename || name, { type: blobMime }))
         setPasteContentBuffer(decrypted)
-        const encoding = chardet.detect(decrypted)
+        const encoding = detectEncoding(decrypted)
         setFileBinary(encoding === null || !utf8CompatibleEncodings.includes(encoding))
         setDecrypted("decrypted")
         setGuessedEncoding(encoding)

--- a/frontend/test/display.spec.tsx
+++ b/frontend/test/display.spec.tsx
@@ -60,6 +60,22 @@ describe("DisplayPaste", () => {
     expect(article.textContent).toStrictEqual(text)
   })
 
+  it("auto-fetches valid UTF-8 text even when chardet guesses a legacy encoding", async () => {
+    const text = "\u043c"
+    server.use(
+      ...mockPaste("abcd", {
+        body: new TextEncoder().encode(text).buffer,
+        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+      }),
+    )
+    vi.stubGlobal("location", new URL("https://example.com/d/abcd"))
+
+    render(<DisplayPaste config={__WRANGLER_CONFIG__} />)
+
+    const article = await screen.findByRole("article")
+    expect(article.textContent).toStrictEqual(text)
+  })
+
   it("renders plain image via raw URL without downloading bytes", async () => {
     // Body is irrelevant: the frontend should not GET it. We still provide a
     // GET handler that would fail loudly if it were called.

--- a/worker/pages/display.ts
+++ b/worker/pages/display.ts
@@ -36,6 +36,18 @@ async function streamToArrayBuffer(stream: ReadableStream<Uint8Array>): Promise<
   return result.buffer
 }
 
+const utf8CompatibleEncodings = ["UTF-8", "ASCII", "ISO-8859-1"]
+
+function detectEncoding(content: ArrayBuffer | Uint8Array): string | null {
+  const bytes = content instanceof Uint8Array ? content : new Uint8Array(content)
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    return "UTF-8"
+  } catch {
+    return chardet.detect(bytes)
+  }
+}
+
 export async function renderDisplayPage(
   env: Env,
   name: string,
@@ -56,9 +68,7 @@ export async function renderDisplayPage(
 
   const content = paste instanceof ArrayBuffer ? paste : await streamToArrayBuffer(paste)
 
-  // Detect binary files
-  const utf8CompatibleEncodings = ["UTF-8", "ASCII", "ISO-8859-1"]
-  const encoding = chardet.detect(new Uint8Array(content))
+  const encoding = detectEncoding(content)
   const isBinary = encoding === null || !utf8CompatibleEncodings.includes(encoding)
 
   const contentBase64 = arrayBufferToBase64(content)


### PR DESCRIPTION
The old detection path trusted `chardet.detect()` before validating whether the bytes are already valid UTF-8. For short valid UTF-8 non-ASCII content, `chardet` can guess a legacy encoding.
This patch validates the bytes with `TextDecoder("utf-8", { fatal: true })` first, and only falls back to chardet.detect() when the bytes are not valid UTF-8.

### Before

The screenshot below was reproduced locally on the base branch with the UTF-8 text `们完准`; `chardet` guessed `windows-1252`, so the display page showed the binary / non-UTF-8 placeholder.
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/f236b91d-6848-4e9e-9233-1903994887a5" />

or

```bash
$ node --input-type=module -e "import chardet from 'chardet'; console.log(chardet.detect(Buffer.from('们完准', 'utf8')))"
windows-1252
```
