### PR TITLE
Fix: SSR, Add: multi file & dir support, QR code, sidebar.

### DIFF
--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -161,7 +161,7 @@ export function CodeEditor({
           isClearable
           defaultItems={availableLanguages.map((lang) => ({ key: lang }))}
           // we must not use undefined here to avoid conversion from uncontrolled component to controlled component
-          selectedKey={lang && availableLanguages.includes(lang) ? lang : ""}
+          selectedKey={lang || ""}
           onSelectionChange={(key) => {
             setLang(key || undefined) // when key is empty string, convert back to undefined
           }}

--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -5,6 +5,7 @@ import { Autocomplete, AutocompleteItem, Input, Select, SelectItem } from "./ui/
 import { autoCompleteOverrides, inputOverrides, selectOverrides, tst } from "../utils/overrides.js"
 import { highlightHTML, useAvailableLanguages, useHljsForLang } from "../utils/highlight.js"
 import { XIcon } from "./icons.js"
+import { DEFAULT_EDIT_FILENAME } from "../../shared/constants.js"
 
 import "../styles/highlight-theme-light.css"
 import "../styles/highlight-theme-dark.css"
@@ -147,7 +148,7 @@ export function CodeEditor({
           classNames={inputOverrides}
           type={"text"}
           label={"File name"}
-          placeholder={"No filename"}
+          placeholder={DEFAULT_EDIT_FILENAME}
           size={"sm"}
           value={filename || ""}
           onValueChange={setFilename}

--- a/frontend/components/CopyWidget.tsx
+++ b/frontend/components/CopyWidget.tsx
@@ -5,9 +5,10 @@ import { CopyIcon, CheckIcon } from "./icons.js"
 
 interface CopyIconProps extends ButtonProps {
   getCopyContent: () => string
+  label?: string
 }
 
-export function CopyWidget({ className, getCopyContent, ...rest }: CopyIconProps) {
+export function CopyWidget({ className = "", getCopyContent, label, ...rest }: CopyIconProps) {
   const numOfIssuedCopies = useRef(0)
   const [hasIssuedCopies, setHasIssuedCopies] = useState<boolean>(false)
   const onCopy = () => {
@@ -28,15 +29,16 @@ export function CopyWidget({ className, getCopyContent, ...rest }: CopyIconProps
 
   return (
     <Button
-      isIconOnly
+      isIconOnly={label === undefined}
       size="sm"
       variant="light"
-      aria-label="Copy"
-      className={`focus:ring-0 hover:bg-default-200 ${className}`}
+      aria-label={label || "Copy"}
+      className={`cursor-pointer focus:ring-0 hover:bg-default-200 ${label ? "gap-1.5 whitespace-nowrap px-2" : ""} ${className}`}
       onPress={onCopy}
       {...rest}
     >
       {hasIssuedCopies ? <CheckIcon className="size-6" /> : <CopyIcon className="size-6" />}
+      {label && <span>{label}</span>}
     </Button>
   )
 }

--- a/frontend/components/CopyWidget.tsx
+++ b/frontend/components/CopyWidget.tsx
@@ -37,7 +37,11 @@ export function CopyWidget({ className = "", getCopyContent, label, ...rest }: C
       onPress={onCopy}
       {...rest}
     >
-      {hasIssuedCopies ? <CheckIcon className="size-6" /> : <CopyIcon className="size-6" />}
+      {hasIssuedCopies ? (
+        <CheckIcon className="size-6 text-default-600" />
+      ) : (
+        <CopyIcon className="size-6 text-default-600" />
+      )}
       {label && <span>{label}</span>}
     </Button>
   )

--- a/frontend/components/DarkModeToggle.tsx
+++ b/frontend/components/DarkModeToggle.tsx
@@ -3,13 +3,13 @@ import React, { useEffect, useState, useSyncExternalStore } from "react"
 import type { ButtonProps } from "./ui/index.js"
 import { Button, Tooltip } from "./ui/index.js"
 
-import { ComputerIcon, MoonIcon, SunIcon } from "./icons.js"
+import { AutoThemeIcon, MoonIcon, SunIcon } from "./icons.js"
 import { tst } from "../utils/overrides.js"
 
 const modeSelections = ["system", "light", "dark"]
 type ModeSelection = (typeof modeSelections)[number]
 const icons: Record<ModeSelection, JSX.Element> = {
-  system: <ComputerIcon className="size-6 inline" />,
+  system: <AutoThemeIcon className="size-6 inline" />,
   light: <SunIcon className="size-6 inline" />,
   dark: <MoonIcon className="size-6 inline" />,
 }
@@ -66,7 +66,7 @@ interface MyComponentProps extends ButtonProps {
   setModeSelection: React.Dispatch<React.SetStateAction<ModeSelection | undefined>>
 }
 
-export function DarkModeToggle({ modeSelection, setModeSelection, className, ...rest }: MyComponentProps) {
+export function DarkModeToggle({ modeSelection, setModeSelection, className = "", ...rest }: MyComponentProps) {
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -81,8 +81,8 @@ export function DarkModeToggle({ modeSelection, setModeSelection, className, ...
         isIconOnly
         size="sm"
         variant="light"
-        className={`${tst}` + " " + className}
-        aria-label="Toggle dark mode"
+        className={`cursor-pointer text-default-600 ${tst} ${className}`}
+        aria-label="Theme"
         style={{ visibility: "hidden" }}
         {...rest}
       >
@@ -92,13 +92,13 @@ export function DarkModeToggle({ modeSelection, setModeSelection, className, ...
   }
 
   return (
-    <Tooltip content={`Toggle dark mode (currently ${currentMode} mode)`}>
+    <Tooltip content={`Using ${currentMode} theme`}>
       <Button
         isIconOnly
         size="sm"
         variant="light"
-        className={`${tst}` + " " + className}
-        aria-label="Toggle dark mode"
+        className={`cursor-pointer text-default-600 ${tst} ${className}`}
+        aria-label="Theme"
         onPress={() => {
           const newSelected = modeSelections[(modeSelections.indexOf(currentMode) + 1) % modeSelections.length]
           setModeSelection(newSelected)

--- a/frontend/components/FileTree.tsx
+++ b/frontend/components/FileTree.tsx
@@ -1,0 +1,222 @@
+import { useMemo, useState } from "react"
+import { formatSize } from "../utils/utils.js"
+import { ChevronDownIcon, FileIcon, FolderIcon } from "./icons.js"
+import { tst } from "../utils/overrides.js"
+import { itemCountLabel } from "../../shared/format.js"
+
+export interface FileTreeEntry {
+  name: string
+  sizeBytes: number
+}
+
+interface FileTreeNode {
+  name: string
+  path: string
+  type: "file" | "folder"
+  sizeBytes: number
+  children: FileTreeNode[]
+}
+
+interface MutableFileTreeNode {
+  name: string
+  path: string
+  type: "file" | "folder"
+  sizeBytes: number
+  children: Map<string, MutableFileTreeNode>
+}
+
+interface FileTreeProps {
+  files: FileTreeEntry[]
+  className?: string
+  compact?: boolean
+}
+
+function normalizedFilePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\/+/, "")
+}
+
+function childKey(type: FileTreeNode["type"], name: string): string {
+  return `${type}:${name}`
+}
+
+function toReadonlyNode(node: MutableFileTreeNode): FileTreeNode {
+  const children = Array.from(node.children.values())
+    .map(toReadonlyNode)
+    .sort((a, b) => {
+      if (a.type !== b.type) return a.type === "folder" ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+  return { ...node, children }
+}
+
+function buildFileTree(files: FileTreeEntry[]): FileTreeNode[] {
+  const root = new Map<string, MutableFileTreeNode>()
+
+  function getOrCreateFolder(
+    siblings: Map<string, MutableFileTreeNode>,
+    name: string,
+    path: string,
+  ): MutableFileTreeNode {
+    const key = childKey("folder", name)
+    const existing = siblings.get(key)
+    if (existing) return existing
+
+    const node: MutableFileTreeNode = {
+      name,
+      path,
+      type: "folder",
+      sizeBytes: 0,
+      children: new Map(),
+    }
+    siblings.set(key, node)
+    return node
+  }
+
+  for (const file of files) {
+    const path = normalizedFilePath(file.name)
+    if (!path) continue
+
+    const isFolder = path.endsWith("/")
+    const parts = path.split("/").filter(Boolean)
+    let siblings = root
+    let currentPath = ""
+
+    parts.forEach((part, index) => {
+      const isLast = index === parts.length - 1
+      currentPath += `${part}${isLast && !isFolder ? "" : "/"}`
+
+      if (isLast && !isFolder) {
+        siblings.set(childKey("file", part), {
+          name: part,
+          path: currentPath,
+          type: "file",
+          sizeBytes: file.sizeBytes,
+          children: new Map(),
+        })
+        return
+      }
+
+      const folder = getOrCreateFolder(siblings, part, currentPath)
+      siblings = folder.children
+    })
+  }
+
+  return Array.from(root.values())
+    .map(toReadonlyNode)
+    .sort((a, b) => {
+      if (a.type !== b.type) return a.type === "folder" ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+}
+
+function FolderMeta({ node }: { node: FileTreeNode }) {
+  if (node.children.length === 0) return <span>0 item</span>
+  return <span>{itemCountLabel(node.children.length)}</span>
+}
+
+function FileTreeRows({
+  nodes,
+  depth,
+  expandedPaths,
+  toggleExpanded,
+  compact,
+}: {
+  nodes: FileTreeNode[]
+  depth: number
+  expandedPaths: Set<string>
+  toggleExpanded: (path: string) => void
+  compact: boolean
+}) {
+  return (
+    <>
+      {nodes.map((node) => {
+        const isExpanded = expandedPaths.has(node.path)
+        const indent = { paddingLeft: `${depth * (compact ? 0.5 : 0.8)}rem` }
+
+        if (node.type === "folder") {
+          return (
+            <div key={`folder-${node.path}`}>
+              <button
+                type="button"
+                className={
+                  `flex w-full cursor-pointer items-center rounded px-1 py-1 text-left hover:bg-default-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-default-400 ${tst} ` +
+                  (compact ? "justify-between gap-1.5" : "justify-between gap-3")
+                }
+                style={indent}
+                aria-expanded={isExpanded}
+                onClick={() => toggleExpanded(node.path)}
+              >
+                <span className="flex min-w-0 items-center">
+                  <span className="flex shrink-0 items-center gap-0">
+                    <ChevronDownIcon className={`size-4 shrink-0 ${isExpanded ? "" : "-rotate-90"}`} />
+                    <FolderIcon className="size-4 shrink-0 text-foreground-500" />
+                  </span>
+                  <span className="ml-1 truncate" title={node.path}>
+                    {node.name}
+                  </span>
+                </span>
+                <span className="shrink-0 text-xs text-foreground-500">
+                  <FolderMeta node={node} />
+                </span>
+              </button>
+              {isExpanded && node.children.length > 0 && (
+                <FileTreeRows
+                  nodes={node.children}
+                  depth={depth + 1}
+                  expandedPaths={expandedPaths}
+                  toggleExpanded={toggleExpanded}
+                  compact={compact}
+                />
+              )}
+            </div>
+          )
+        }
+
+        return (
+          <div
+            key={`file-${node.path}`}
+            className="flex items-center justify-between gap-3 rounded px-1 py-1"
+            style={indent}
+          >
+            <span className="flex min-w-0 items-center">
+              <span className="flex shrink-0 items-center gap-0">
+                <span className="size-4 shrink-0" />
+                <FileIcon className="size-4 shrink-0 text-foreground-500" />
+              </span>
+              <span className="ml-1 truncate" title={node.path}>
+                {node.name}
+              </span>
+            </span>
+            <span className="shrink-0 text-xs text-foreground-500">{formatSize(node.sizeBytes)}</span>
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export function FileTree({ files, className = "", compact = false }: FileTreeProps) {
+  const nodes = useMemo(() => buildFileTree(files), [files])
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set())
+
+  function toggleExpanded(path: string) {
+    setExpandedPaths((current) => {
+      const next = new Set(current)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+
+  return (
+    <div className={`text-sm text-foreground-600 ${className}`}>
+      <FileTreeRows
+        nodes={nodes}
+        depth={0}
+        expandedPaths={expandedPaths}
+        toggleExpanded={toggleExpanded}
+        compact={compact}
+      />
+    </div>
+  )
+}

--- a/frontend/components/LocalUploadsSidebar.tsx
+++ b/frontend/components/LocalUploadsSidebar.tsx
@@ -50,8 +50,8 @@ export function LocalUploadsSidebar({
   const [deletingKey, setDeletingKey] = useState<string | undefined>(undefined)
   const [now, setNow] = useState(() => Date.now())
   const actionClass =
-    `inline-flex h-[38px] cursor-pointer items-center gap-1.5 rounded-xl bg-default-100 px-2 ` +
-    `text-sm text-foreground hover:bg-default-200 ${tst}`
+    `inline-flex h-[30px] cursor-pointer items-center gap-1.5 rounded-xl bg-default-100 px-2 ` +
+    `text-xs text-foreground hover:bg-default-200 ${tst}`
 
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), 60000)
@@ -95,17 +95,17 @@ export function LocalUploadsSidebar({
 
             return (
               <Card key={upload.key} className="rounded-lg border border-default-200" style={{ boxShadow: "none" }}>
-                <CardBody className="px-3 py-2.5">
+                <CardBody className="px-3 pt-2 pb-1.5">
                   <div className="flex items-start gap-2">
-                    <div className="mt-1 flex shrink-0 items-center justify-center text-foreground">
+                    <div className="mt-1 flex shrink-0 items-center justify-center text-default-600">
                       <FileIcon className="size-6" />
                     </div>
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-base font-medium" title={displayName}>
+                      <div className="truncate text-sm font-medium" title={displayName}>
                         {displayName}
                       </div>
-                      <div className="mt-0.5 text-sm text-default-500">{formatSize(upload.sizeBytes)}</div>
-                      <div className="mt-1 text-sm text-default-700">{formatTimeLeft(upload.expireAt, now)}</div>
+                      <div className="mt-0.5 text-xs text-default-500">{formatSize(upload.sizeBytes)}</div>
+                      <div className="mt-1 text-[13px] text-default-700">{formatTimeLeft(upload.expireAt, now)}</div>
 
                       {hasFilenames && (
                         <>
@@ -162,7 +162,7 @@ export function LocalUploadsSidebar({
                     </Tooltip>
                   </div>
 
-                  <div className="my-2 border-t border-divider" />
+                  <div className="mt-1 mb-1.5 border-t border-divider" />
 
                   <div className="flex items-center justify-between">
                     <a
@@ -171,7 +171,7 @@ export function LocalUploadsSidebar({
                       rel="noreferrer"
                       className={actionClass}
                     >
-                      <ExternalLinkIcon className="size-5" />
+                      <ExternalLinkIcon className="size-6 text-default-600" />
                       <span>Open</span>
                     </a>
                     <CopyWidget

--- a/frontend/components/LocalUploadsSidebar.tsx
+++ b/frontend/components/LocalUploadsSidebar.tsx
@@ -7,6 +7,8 @@ import { Button, Card, CardBody, Tooltip } from "./ui/index.js"
 import { ChevronDownIcon, ExternalLinkIcon, FileIcon, TrashIcon } from "./icons.js"
 import { CopyWidget } from "./CopyWidget.js"
 import { tst } from "../utils/overrides.js"
+import { FileTree } from "./FileTree.js"
+import { itemCountLabel } from "../../shared/format.js"
 
 interface LocalUploadsSidebarProps {
   uploads: LocalUploadRecord[]
@@ -123,21 +125,11 @@ export function LocalUploadsSidebar({
                             }}
                           >
                             <ChevronDownIcon className={`size-4 ${isExpanded ? "" : "-rotate-90"}`} />
-                            <span>{upload.filenames!.length} files</span>
+                            <span>{itemCountLabel(upload.filenames!.length)}</span>
                           </button>
                           {isExpanded && (
-                            <div className="mt-2 max-h-40 overflow-auto rounded-md bg-default-100 px-2 py-1">
-                              {upload.filenames!.map((file, index) => (
-                                <div
-                                  key={`${file.name}-${index}`}
-                                  className="flex items-baseline justify-between gap-3 py-1 text-sm"
-                                >
-                                  <span className="min-w-0 truncate" title={file.name}>
-                                    {file.name}
-                                  </span>
-                                  <span className="shrink-0 text-xs text-default-500">{formatSize(file.sizeBytes)}</span>
-                                </div>
-                              ))}
+                            <div className="mt-2 max-h-48 overflow-auto rounded-md bg-default-100">
+                              <FileTree files={upload.filenames!} compact />
                             </div>
                           )}
                         </>
@@ -165,20 +157,11 @@ export function LocalUploadsSidebar({
                   <div className="mt-1 mb-1.5 border-t border-divider" />
 
                   <div className="flex items-center justify-between">
-                    <a
-                      href={upload.displayUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className={actionClass}
-                    >
+                    <a href={upload.displayUrl} target="_blank" rel="noreferrer" className={actionClass}>
                       <ExternalLinkIcon className="size-6 text-default-600" />
                       <span>Open</span>
                     </a>
-                    <CopyWidget
-                      label="Copy link"
-                      className={actionClass}
-                      getCopyContent={() => upload.displayUrl}
-                    />
+                    <CopyWidget label="Copy link" className={actionClass} getCopyContent={() => upload.displayUrl} />
                   </div>
                 </CardBody>
               </Card>

--- a/frontend/components/LocalUploadsSidebar.tsx
+++ b/frontend/components/LocalUploadsSidebar.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useRef, useState } from "react"
+import type { CSSProperties } from "react"
+
+import type { LocalUploadRecord } from "../utils/localUploads.js"
+import { formatSize } from "../utils/utils.js"
+import { Button, Card, CardBody, Tooltip } from "./ui/index.js"
+import { ChevronDownIcon, ExternalLinkIcon, FileIcon, TrashIcon } from "./icons.js"
+import { CopyWidget } from "./CopyWidget.js"
+import { tst } from "../utils/overrides.js"
+
+interface LocalUploadsSidebarProps {
+  uploads: LocalUploadRecord[]
+  onDeleteUpload: (upload: LocalUploadRecord) => Promise<void>
+  scrollToKey?: string
+  className?: string
+  style?: CSSProperties
+}
+
+function getDisplayName(upload: LocalUploadRecord): string {
+  return upload.filename || upload.key
+}
+
+function formatTimeLeft(expireAt: string, now: number): string {
+  const diffMs = new Date(expireAt).getTime() - now
+  if (!Number.isFinite(diffMs)) return "Expiration unknown"
+  if (diffMs <= 0) return "Expired"
+
+  const totalMinutes = Math.ceil(diffMs / 60000)
+  const days = Math.floor(totalMinutes / 1440)
+  const hours = Math.floor(totalMinutes / 60)
+
+  if (days > 0) {
+    return `Expires in ${days}d`
+  }
+  if (hours > 0) {
+    return `Expires in ${hours}h`
+  }
+  return `Expires in ${totalMinutes}m`
+}
+
+export function LocalUploadsSidebar({
+  uploads,
+  onDeleteUpload,
+  scrollToKey,
+  className = "",
+  style,
+}: LocalUploadsSidebarProps) {
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(() => new Set())
+  const [deletingKey, setDeletingKey] = useState<string | undefined>(undefined)
+  const [now, setNow] = useState(() => Date.now())
+  const actionClass =
+    `inline-flex h-[38px] cursor-pointer items-center gap-1.5 rounded-xl bg-default-100 px-2 ` +
+    `text-sm text-foreground hover:bg-default-200 ${tst}`
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 60000)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  useEffect(() => {
+    if (scrollToKey !== undefined) {
+      listRef.current?.scrollTo?.({ top: 0 })
+    }
+  }, [scrollToKey])
+
+  async function deleteUpload(upload: LocalUploadRecord) {
+    setDeletingKey(upload.key)
+    try {
+      await onDeleteUpload(upload)
+    } finally {
+      setDeletingKey(undefined)
+    }
+  }
+
+  return (
+    <aside
+      className={`flex w-full flex-col xl:mt-6 xl:h-[calc(var(--local-uploads-height)-1.5rem)] xl:max-h-[calc(var(--local-uploads-height)-1.5rem)] xl:w-75 xl:overflow-hidden ${className}`}
+      style={style}
+    >
+      {uploads.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-default-300 px-4 py-4 text-sm text-default-500">
+          Uploads from this browser will appear here.
+        </div>
+      ) : (
+        <div
+          ref={listRef}
+          className="flex max-h-[calc(100vh-1rem)] flex-col gap-2 overflow-y-auto px-1 xl:min-h-0 xl:max-h-none xl:flex-1 xl:overscroll-contain"
+        >
+          {uploads.map((upload) => {
+            const isExpanded = expandedKeys.has(upload.key)
+            const hasFilenames = upload.filenames !== undefined && upload.filenames.length > 0
+            const isDeleting = deletingKey === upload.key
+            const displayName = getDisplayName(upload)
+
+            return (
+              <Card key={upload.key} className="rounded-lg border border-default-200" style={{ boxShadow: "none" }}>
+                <CardBody className="px-3 py-2.5">
+                  <div className="flex items-start gap-2">
+                    <div className="mt-1 flex shrink-0 items-center justify-center text-foreground">
+                      <FileIcon className="size-6" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-base font-medium" title={displayName}>
+                        {displayName}
+                      </div>
+                      <div className="mt-0.5 text-sm text-default-500">{formatSize(upload.sizeBytes)}</div>
+                      <div className="mt-1 text-sm text-default-700">{formatTimeLeft(upload.expireAt, now)}</div>
+
+                      {hasFilenames && (
+                        <>
+                          <button
+                            type="button"
+                            className={`mt-1 inline-flex cursor-pointer items-center gap-1 text-sm text-primary hover:underline focus:outline-none focus-visible:ring-1 focus-visible:ring-default-400 rounded ${tst}`}
+                            aria-expanded={isExpanded}
+                            onClick={() => {
+                              setExpandedKeys((current) => {
+                                const next = new Set(current)
+                                if (next.has(upload.key)) next.delete(upload.key)
+                                else next.add(upload.key)
+                                return next
+                              })
+                            }}
+                          >
+                            <ChevronDownIcon className={`size-4 ${isExpanded ? "" : "-rotate-90"}`} />
+                            <span>{upload.filenames!.length} files</span>
+                          </button>
+                          {isExpanded && (
+                            <div className="mt-2 max-h-40 overflow-auto rounded-md bg-default-100 px-2 py-1">
+                              {upload.filenames!.map((file, index) => (
+                                <div
+                                  key={`${file.name}-${index}`}
+                                  className="flex items-baseline justify-between gap-3 py-1 text-sm"
+                                >
+                                  <span className="min-w-0 truncate" title={file.name}>
+                                    {file.name}
+                                  </span>
+                                  <span className="shrink-0 text-xs text-default-500">{formatSize(file.sizeBytes)}</span>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
+                    <Tooltip content="Delete" placement="bottom">
+                      <Button
+                        type="button"
+                        isIconOnly
+                        size="sm"
+                        variant="light"
+                        color="danger"
+                        aria-label={`Delete ${displayName}`}
+                        disabled={isDeleting}
+                        className="shrink-0 cursor-pointer text-default-500 hover:text-danger disabled:cursor-not-allowed"
+                        onPress={() => {
+                          void deleteUpload(upload)
+                        }}
+                      >
+                        <TrashIcon className="size-5" />
+                      </Button>
+                    </Tooltip>
+                  </div>
+
+                  <div className="my-2 border-t border-divider" />
+
+                  <div className="flex items-center justify-between">
+                    <a
+                      href={upload.displayUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={actionClass}
+                    >
+                      <ExternalLinkIcon className="size-5" />
+                      <span>Open</span>
+                    </a>
+                    <CopyWidget
+                      label="Copy link"
+                      className={actionClass}
+                      getCopyContent={() => upload.displayUrl}
+                    />
+                  </div>
+                </CardBody>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/frontend/components/PasteInputPanel.tsx
+++ b/frontend/components/PasteInputPanel.tsx
@@ -6,6 +6,8 @@ import { formatSize, verifyFileSize } from "../utils/utils.js"
 import { XIcon } from "./icons.js"
 import { cardOverrides, tst } from "../utils/overrides.js"
 import { CodeEditor } from "./CodeEditor.js"
+import { FileTree } from "./FileTree.js"
+import { itemCountLabel } from "../../shared/format.js"
 
 export type EditKind = "edit" | "file"
 
@@ -17,17 +19,125 @@ export interface PasteEditState {
   files: File[]
 }
 
-function filesFromDataTransferItems(items: DataTransferItemList | undefined): File[] {
+interface FileSystemEntryLike {
+  isFile: boolean
+  isDirectory: boolean
+  name: string
+}
+
+interface FileSystemFileEntryLike extends FileSystemEntryLike {
+  isFile: true
+  isDirectory: false
+  file: (success: (file: File) => void, error?: (error: DOMException) => void) => void
+}
+
+interface FileSystemDirectoryReaderLike {
+  readEntries: (success: (entries: FileSystemEntryLike[]) => void, error?: (error: DOMException) => void) => void
+}
+
+interface FileSystemDirectoryEntryLike extends FileSystemEntryLike {
+  isFile: false
+  isDirectory: true
+  createReader: () => FileSystemDirectoryReaderLike
+}
+
+type TransferFileRecord = { kind: "entry"; entry: FileSystemEntryLike } | { kind: "file"; file: File }
+
+function fileWithPath(file: File, path: string): File {
+  if (file.name === path) return file
+  return new File([file], path, { type: file.type, lastModified: file.lastModified })
+}
+
+function emptyFolderFile(path: string): File {
+  return new File([new Uint8Array(0)], path)
+}
+
+function pathJoin(parentPath: string, name: string): string {
+  return `${parentPath}${name}`
+}
+
+function readFileEntry(entry: FileSystemFileEntryLike): Promise<File> {
+  return new Promise((resolve, reject) => entry.file(resolve, reject))
+}
+
+function readDirectoryBatch(reader: FileSystemDirectoryReaderLike): Promise<FileSystemEntryLike[]> {
+  return new Promise((resolve, reject) => reader.readEntries(resolve, reject))
+}
+
+async function readAllDirectoryEntries(entry: FileSystemDirectoryEntryLike): Promise<FileSystemEntryLike[]> {
+  const reader = entry.createReader()
+  const entries: FileSystemEntryLike[] = []
+
+  while (true) {
+    const batch = await readDirectoryBatch(reader)
+    if (batch.length === 0) break
+    entries.push(...batch)
+  }
+
+  return entries
+}
+
+async function filesFromEntry(entry: FileSystemEntryLike, parentPath = ""): Promise<File[]> {
+  if (entry.isFile) {
+    const file = await readFileEntry(entry as FileSystemFileEntryLike)
+    return [fileWithPath(file, pathJoin(parentPath, file.name))]
+  }
+
+  if (entry.isDirectory) {
+    const directoryPath = `${pathJoin(parentPath, entry.name)}/`
+    const children = await readAllDirectoryEntries(entry as FileSystemDirectoryEntryLike)
+    if (children.length === 0) return [emptyFolderFile(directoryPath)]
+
+    const nestedFiles = await Promise.all(children.map((child) => filesFromEntry(child, directoryPath)))
+    return nestedFiles.flat()
+  }
+
+  return []
+}
+
+function transferRecordsFromDataTransferItems(items: DataTransferItemList | undefined): TransferFileRecord[] {
   if (!items) return []
-  return Array.from(items)
-    .filter((item) => item.kind === "file")
-    .map((item) => item.getAsFile())
-    .filter((file): file is File => file !== null)
+  const records: TransferFileRecord[] = []
+
+  for (const item of Array.from(items)) {
+    if (item.kind !== "file") continue
+
+    const entry = (
+      item as DataTransferItem & { webkitGetAsEntry?: () => FileSystemEntryLike | null }
+    ).webkitGetAsEntry?.()
+    if (entry) {
+      records.push({ kind: "entry", entry })
+      continue
+    }
+
+    const file = item.getAsFile()
+    if (file) records.push({ kind: "file", file })
+  }
+
+  return records
+}
+
+async function filesFromTransferRecords(records: TransferFileRecord[]): Promise<File[]> {
+  const files = await Promise.all(
+    records.map((record) => (record.kind === "entry" ? filesFromEntry(record.entry) : Promise.resolve([record.file]))),
+  )
+  return files.flat()
+}
+
+function filesFromFileList(files: FileList | null | undefined): File[] {
+  if (!files) return []
+  return Array.from(files).map((file) => {
+    const path = file.webkitRelativePath || file.name
+    return fileWithPath(file, path)
+  })
 }
 
 function isPasteEditorFocused(): boolean {
   const activeElement = document.activeElement
-  return activeElement instanceof HTMLTextAreaElement || (activeElement instanceof HTMLInputElement && !activeElement.readOnly)
+  return (
+    activeElement instanceof HTMLTextAreaElement ||
+    (activeElement instanceof HTMLInputElement && !activeElement.readOnly)
+  )
 }
 
 function totalFileSize(files: File[]): number {
@@ -53,45 +163,75 @@ export function PasteInputPanel({
   const fileInput = useRef<HTMLInputElement>(null)
   const [isDragged, setDragged] = useState<boolean>(false)
   const [isEditDragged, setEditDragged] = useState<boolean>(false)
+  const [isCollectingFiles, setIsCollectingFiles] = useState<boolean>(false)
 
   const resetFileInput = useCallback(() => {
     if (fileInput.current) fileInput.current.value = ""
   }, [])
 
-  const setFiles = useCallback((files: File[]) => {
-    const totalSize = totalFileSize(files)
-    const [totalOk, totalMsg] = verifyFileSize(totalSize, config)
-    if (!totalOk) {
-      showModal(files.length > 1 ? "Files too large" : "File too large", totalMsg)
-      resetFileInput()
-      return
-    }
+  const setFiles = useCallback(
+    (files: File[]) => {
+      const totalSize = totalFileSize(files)
+      const [totalOk, totalMsg] = verifyFileSize(totalSize, config)
+      if (!totalOk) {
+        showModal(files.length > 1 ? "Pastes too large" : "Paste too large", totalMsg)
+        resetFileInput()
+        return
+      }
 
-    onStateChange({ ...state, editKind: "file", files })
-  }, [config, onStateChange, resetFileInput, showModal, state])
+      onStateChange({ ...state, editKind: "file", files })
+    },
+    [config, onStateChange, resetFileInput, showModal, state],
+  )
+
+  const collectAndSetFiles = useCallback(
+    async (records: TransferFileRecord[]) => {
+      if (records.length === 0) return
+
+      setIsCollectingFiles(true)
+      try {
+        const files = await filesFromTransferRecords(records)
+        if (files.length > 0) setFiles(files)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "The selected files could not be read."
+        showModal("Could not read files", message)
+        resetFileInput()
+      } finally {
+        setIsCollectingFiles(false)
+      }
+    },
+    [resetFileInput, setFiles, showModal],
+  )
 
   useEffect(() => {
     function onPaste(e: ClipboardEvent) {
       if (isPasteEditorFocused()) return
 
-      const files = filesFromDataTransferItems(e.clipboardData?.items)
-      if (files.length === 0) return
+      const records = transferRecordsFromDataTransferItems(e.clipboardData?.items)
+      if (records.length === 0) return
 
       e.preventDefault()
-      setFiles(files)
+      void collectAndSetFiles(records)
     }
 
     document.addEventListener("paste", onPaste)
     return () => document.removeEventListener("paste", onPaste)
-  }, [setFiles])
+  }, [collectAndSetFiles])
 
   function onDrop(e: DragEvent) {
     e.preventDefault()
-    const files = filesFromDataTransferItems(e.dataTransfer?.items)
-    if (files.length > 0) setFiles(files)
+    const records = transferRecordsFromDataTransferItems(e.dataTransfer?.items)
+    if (records.length > 0) {
+      void collectAndSetFiles(records)
+    } else {
+      const files = filesFromFileList(e.dataTransfer?.files)
+      if (files.length > 0) setFiles(files)
+    }
     setDragged(false)
     setEditDragged(false)
   }
+
+  const shouldShowFileTree = state.files.length > 1 || state.files.some((file) => file.name.includes("/"))
 
   return (
     <Card aria-label="Pastebin editor panel" classNames={cardOverrides} {...rest}>
@@ -101,10 +241,8 @@ export function PasteInputPanel({
           ref={fileInput}
           className="hidden"
           onChange={(e) => {
-            const files = e.target.files
-            if (files?.length) {
-              setFiles(Array.from(files))
-            }
+            const files = filesFromFileList(e.target.files)
+            if (files.length > 0) setFiles(files)
           }}
           multiple
         />
@@ -158,7 +296,7 @@ export function PasteInputPanel({
                   }
                   aria-hidden="true"
                 >
-                  <div className="text-2xl my-2 font-bold">Drop file here</div>
+                  <div className="text-2xl my-2 font-bold">Drop files or folders here</div>
                   <p className="text-1xl text-foreground-500">Release to upload as file</p>
                 </div>
               )}
@@ -182,11 +320,15 @@ export function PasteInputPanel({
               onClick={() => fileInput.current?.click()}
             >
               <div className="text-2xl my-2 font-bold px-4 text-center break-all">
-                {state.files.length === 0
-                  ? "Select Files"
-                  : state.files.length === 1
-                    ? state.files[0].name
-                    : `${state.files.length} files selected`}
+                {isCollectingFiles
+                  ? "Reading files..."
+                  : state.files.length === 0
+                    ? "Select Files"
+                    : state.files.length === 1
+                      ? state.files[0].name.includes("/")
+                        ? `${itemCountLabel(state.files.length)} selected`
+                        : state.files[0].name
+                      : `${itemCountLabel(state.files.length)} selected`}
               </div>
               <p className={`text-1xl text-foreground-500 ${tst} relative`}>
                 <span>
@@ -195,14 +337,12 @@ export function PasteInputPanel({
                     : "Click or drag & drop or paste files here"}
                 </span>
               </p>
-              {state.files.length > 1 && (
-                <div className="mt-3 max-h-32 overflow-auto text-sm text-foreground-600 w-full max-w-[32rem] px-4">
-                  {state.files.map((file, index) => (
-                    <div key={`${file.name}-${index}`} className="flex justify-between gap-4">
-                      <span className="truncate">{file.name}</span>
-                      <span className="shrink-0">{formatSize(file.size)}</span>
-                    </div>
-                  ))}
+              {shouldShowFileTree && (
+                <div
+                  className="mt-3 max-h-48 overflow-auto text-sm text-foreground-600 w-full max-w-[32rem] px-4"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <FileTree files={state.files.map((file) => ({ name: file.name, sizeBytes: file.size }))} />
                 </div>
               )}
               {state.files.length > 0 && (

--- a/frontend/components/PasteInputPanel.tsx
+++ b/frontend/components/PasteInputPanel.tsx
@@ -1,7 +1,7 @@
 import type { CardProps } from "./ui/index.js"
 import { Card, CardBody, Tab, Tabs } from "./ui/index.js"
 import type { DragEvent } from "react"
-import { useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { formatSize, verifyFileSize } from "../utils/utils.js"
 import { XIcon } from "./icons.js"
 import { cardOverrides, tst } from "../utils/overrides.js"
@@ -14,7 +14,24 @@ export interface PasteEditState {
   editContent: string
   editFilename?: string
   editHighlightLang?: string
-  file: File | null
+  files: File[]
+}
+
+function filesFromDataTransferItems(items: DataTransferItemList | undefined): File[] {
+  if (!items) return []
+  return Array.from(items)
+    .filter((item) => item.kind === "file")
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => file !== null)
+}
+
+function isPasteEditorFocused(): boolean {
+  const activeElement = document.activeElement
+  return activeElement instanceof HTMLTextAreaElement || (activeElement instanceof HTMLInputElement && !activeElement.readOnly)
+}
+
+function totalFileSize(files: File[]): number {
+  return files.reduce((sum, file) => sum + file.size, 0)
 }
 
 interface PasteEditorProps extends CardProps {
@@ -37,31 +54,41 @@ export function PasteInputPanel({
   const [isDragged, setDragged] = useState<boolean>(false)
   const [isEditDragged, setEditDragged] = useState<boolean>(false)
 
-  function setFile(file: File | null) {
-    if (file) {
-      const [ok, msg] = verifyFileSize(file.size, config)
-      if (!ok) {
-        showModal("File too large", msg)
-        // also reset the underlying input so picking the same file again re-triggers onChange
-        if (fileInput.current) fileInput.current.value = ""
-        return
-      }
+  const resetFileInput = useCallback(() => {
+    if (fileInput.current) fileInput.current.value = ""
+  }, [])
+
+  const setFiles = useCallback((files: File[]) => {
+    const totalSize = totalFileSize(files)
+    const [totalOk, totalMsg] = verifyFileSize(totalSize, config)
+    if (!totalOk) {
+      showModal(files.length > 1 ? "Files too large" : "File too large", totalMsg)
+      resetFileInput()
+      return
     }
-    onStateChange({ ...state, editKind: "file", file })
-  }
+
+    onStateChange({ ...state, editKind: "file", files })
+  }, [config, onStateChange, resetFileInput, showModal, state])
+
+  useEffect(() => {
+    function onPaste(e: ClipboardEvent) {
+      if (isPasteEditorFocused()) return
+
+      const files = filesFromDataTransferItems(e.clipboardData?.items)
+      if (files.length === 0) return
+
+      e.preventDefault()
+      setFiles(files)
+    }
+
+    document.addEventListener("paste", onPaste)
+    return () => document.removeEventListener("paste", onPaste)
+  }, [setFiles])
 
   function onDrop(e: DragEvent) {
     e.preventDefault()
-    const items = e.dataTransfer?.items
-    if (items) {
-      for (const item of Array.from(items)) {
-        if (item.kind === "file") {
-          const file = item.getAsFile()!
-          setFile(file)
-          break
-        }
-      }
-    }
+    const files = filesFromDataTransferItems(e.dataTransfer?.items)
+    if (files.length > 0) setFiles(files)
     setDragged(false)
     setEditDragged(false)
   }
@@ -76,9 +103,10 @@ export function PasteInputPanel({
           onChange={(e) => {
             const files = e.target.files
             if (files?.length) {
-              setFile(files[0])
+              setFiles(Array.from(files))
             }
           }}
+          multiple
         />
         <Tabs
           variant="underlined"
@@ -91,7 +119,6 @@ export function PasteInputPanel({
           selectedKey={state.editKind}
           onSelectionChange={(k) => {
             onStateChange({ ...state, editKind: k as EditKind })
-            if (k === "file") fileInput.current?.click()
           }}
         >
           {/*Possibly a bug of chrome, but Tab sometimes has a transient unexpected scrollbar when resizing*/}
@@ -155,23 +182,38 @@ export function PasteInputPanel({
               onClick={() => fileInput.current?.click()}
             >
               <div className="text-2xl my-2 font-bold px-4 text-center break-all">
-                {state.file !== null ? state.file.name : "Select File"}
+                {state.files.length === 0
+                  ? "Select Files"
+                  : state.files.length === 1
+                    ? state.files[0].name
+                    : `${state.files.length} files selected`}
               </div>
               <p className={`text-1xl text-foreground-500 ${tst} relative`}>
                 <span>
-                  {state.file !== null
-                    ? `${formatSize(state.file.size)} · Click or drag to replace`
-                    : "Click or drag & drop file here"}
+                  {state.files.length > 0
+                    ? `${formatSize(totalFileSize(state.files))} · Click or drag or paste to replace`
+                    : "Click or drag & drop or paste files here"}
                 </span>
               </p>
-              {state.file && (
+              {state.files.length > 1 && (
+                <div className="mt-3 max-h-32 overflow-auto text-sm text-foreground-600 w-full max-w-[32rem] px-4">
+                  {state.files.map((file, index) => (
+                    <div key={`${file.name}-${index}`} className="flex justify-between gap-4">
+                      <span className="truncate">{file.name}</span>
+                      <span className="shrink-0">{formatSize(file.size)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {state.files.length > 0 && (
                 <XIcon
                   aria-label="Remove file"
                   role="button"
                   className={`h-6 inline absolute top-2 right-2 text-red-400 ${tst}`}
                   onClick={(e) => {
                     e.stopPropagation()
-                    setFile(null)
+                    setFiles([])
+                    resetFileInput()
                   }}
                 />
               )}

--- a/frontend/components/PasteSettingPanel.tsx
+++ b/frontend/components/PasteSettingPanel.tsx
@@ -124,7 +124,7 @@ export function PanelSettingsPanel({
               base: "basis-40",
               ...inputOverrides,
             }}
-            defaultValue="7d"
+            defaultValue={config.DEFAULT_EXPIRATION}
             value={setting.expiration}
             isRequired
             onValueChange={(e) => onSettingChange({ ...setting, expiration: e })}

--- a/frontend/components/QrCodeTooltip.tsx
+++ b/frontend/components/QrCodeTooltip.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { generate } from "lean-qr/nano"
+import { toSvgDataURL } from "lean-qr/extras/svg"
+
+import { Button, Tooltip } from "./ui/index.js"
+import { QrCodeIcon } from "./icons.js"
+
+function QrCodePreview({ value }: { value: string }) {
+  const qrCodeSrc = useMemo(() => {
+    try {
+      return toSvgDataURL(generate(value), {
+        on: "black",
+        off: "white",
+        pad: 1,
+        width: 200,
+        height: 200,
+      })
+    } catch {
+      return undefined
+    }
+  }, [value])
+
+  if (qrCodeSrc === undefined) {
+    return <div className="px-2 py-1 text-sm">QR code unavailable</div>
+  }
+
+  return (
+    <div className="rounded-md bg-white p-1">
+      <img src={qrCodeSrc} alt="QR code" className="block h-[200px] w-[200px]" />
+    </div>
+  )
+}
+
+export function QrCodeTooltip({
+  value,
+  placement = "top",
+  className = "",
+  tooltip,
+}: {
+  value: string
+  placement?: "auto" | "top" | "bottom"
+  className?: string
+  tooltip?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const actualPlacement = placement === "auto" ? "top" : placement
+
+  useEffect(() => {
+    if (!open) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    document.addEventListener("keydown", handleKeyDown)
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown)
+      document.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [open])
+
+  const button = (
+    <Button
+      type="button"
+      isIconOnly
+      size="sm"
+      variant="light"
+      aria-label={tooltip ?? "Show QR code"}
+      aria-expanded={open}
+      className={`cursor-pointer text-default-600 focus:ring-0 ${className || "hover:bg-default-200"}`}
+      onPress={() => setOpen((current) => !current)}
+    >
+      <QrCodeIcon className="size-6" />
+    </Button>
+  )
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative inline-flex ${open ? "z-50" : ""}`}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && open) {
+          setOpen(false)
+        }
+      }}
+    >
+      {tooltip ? <Tooltip content={tooltip}>{button}</Tooltip> : button}
+      {open && (
+        <div
+          role="dialog"
+          aria-label="QR code"
+          className={`absolute z-50 w-max rounded-lg border border-default-200 bg-content1 p-1 shadow-medium ${
+            actualPlacement === "top" ? "bottom-full mb-2" : "top-full mt-2"
+          } left-1/2 -translate-x-1/2`}
+        >
+          <QrCodePreview value={value} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/QrCodeTooltip.tsx
+++ b/frontend/components/QrCodeTooltip.tsx
@@ -5,12 +5,18 @@ import { toSvgDataURL } from "lean-qr/extras/svg"
 import { Button, Tooltip } from "./ui/index.js"
 import { QrCodeIcon } from "./icons.js"
 
+function getIsDarkMode() {
+  if (typeof document === "undefined") return false
+  return document.documentElement.classList.contains("dark")
+}
+
 function QrCodePreview({ value }: { value: string }) {
   const qrCodeSrc = useMemo(() => {
+    const isDarkMode = getIsDarkMode()
     try {
       return toSvgDataURL(generate(value), {
         on: "black",
-        off: "white",
+        off: isDarkMode ? "#dddddd" : "white",
         pad: 1,
         width: 200,
         height: 200,
@@ -25,8 +31,13 @@ function QrCodePreview({ value }: { value: string }) {
   }
 
   return (
-    <div className="rounded-md bg-white p-1">
-      <img src={qrCodeSrc} alt="QR code" className="block h-[200px] w-[200px]" />
+    <div className="rounded-md bg-white p-1 dark:bg-[#dddddd]">
+      <img
+        src={qrCodeSrc}
+        alt="QR code"
+        className="block aspect-square max-w-[200px]"
+        style={{ width: "min(200px, calc(100vw - 3rem))" }}
+      />
     </div>
   )
 }
@@ -98,9 +109,9 @@ export function QrCodeTooltip({
         <div
           role="dialog"
           aria-label="QR code"
-          className={`absolute z-50 w-max rounded-lg border border-default-200 bg-content1 p-1 shadow-medium ${
-            actualPlacement === "top" ? "bottom-full mb-2" : "top-full mt-2"
-          } left-1/2 -translate-x-1/2`}
+          className={`fixed right-2 z-50 h-fit w-fit max-h-[calc(100dvh-4rem)] max-w-[calc(100vw-1rem)] overflow-auto rounded-lg border border-default-200 bg-content1 p-1 shadow-medium xl:absolute xl:right-auto xl:left-1/2 xl:max-h-none xl:max-w-none xl:-translate-x-1/2 ${
+            actualPlacement === "top" ? "bottom-11 xl:bottom-full xl:mb-2" : "top-17 xl:top-full xl:mt-2"
+          }`}
         >
           <QrCodePreview value={value} />
         </div>

--- a/frontend/components/UploadedPanel.tsx
+++ b/frontend/components/UploadedPanel.tsx
@@ -20,6 +20,7 @@ import { makeDisplayUrl, withPathPrefix } from "../utils/pasteUrls.js"
 import type { UploadProgress } from "../utils/uploader.js"
 import { formatSize } from "../utils/utils.js"
 import { CopyWidget } from "./CopyWidget.js"
+import { QrCodeTooltip } from "./QrCodeTooltip.js"
 import { ChevronDownIcon, InfoIcon } from "./icons.js"
 
 interface UploadedPanelProps extends CardProps {
@@ -112,20 +113,23 @@ export function UploadedPanel({
     label: string,
     value: string,
     labelExtra?: React.ReactNode,
-    options?: { color?: "default" | "success"; copyClassName?: string },
-  ) => (
-    <div className="mb-2 flex items-end gap-2">
-      <Input
-        {...inputProps}
-        className="mb-0 min-w-0 flex-1"
-        label={label}
-        labelExtra={labelExtra}
-        color={options?.color}
-        value={value}
-      />
-      {copyLinkButton(value, options?.copyClassName)}
-    </div>
-  )
+    options?: { color?: "default" | "success"; copyClassName?: string; qrClassName?: string },
+  ) => {
+    return (
+      <div className="mb-2 flex items-end gap-2">
+        <Input
+          {...inputProps}
+          className="mb-0 min-w-0 flex-1"
+          label={label}
+          labelExtra={labelExtra}
+          color={options?.color}
+          value={value}
+          endContent={<QrCodeTooltip value={value} className={options?.qrClassName ?? "hover:bg-default-200"} />}
+        />
+        {copyLinkButton(value, options?.copyClassName)}
+      </div>
+    )
+  }
 
   const markdownUrlField = (pasteResponse: PasteResponse) =>
     urlInput(
@@ -133,6 +137,25 @@ export function UploadedPanel({
       withPathPrefix(pasteResponse.url, "/a"),
       <InfoTooltip>Render the paste as GitHub-flavored markdown (with code highlighting and LaTeX).</InfoTooltip>,
     )
+
+  const displayUrlLabelExtra = (
+    <UrlTooltip
+      desc={
+        <>
+          Browser-friendly view with syntax highlighting.
+          {encryptionKey && (
+            <>
+              {" "}
+              The decryption key sits after the <code className="font-mono">#</code> in the URL and is never sent to the
+              server — it stays in the browser for client-side decryption.
+            </>
+          )}
+        </>
+      }
+      flags={DISPLAY_URL_FLAGS}
+    />
+  )
+  const displayUrl = pasteResponse ? makeDisplayUrl(pasteResponse.url, encryptionKey) : ""
 
   return (
     <Card classNames={mergeClasses({ base: tst }, { base: className })} {...rest}>
@@ -159,29 +182,11 @@ export function UploadedPanel({
         ) : (
           pasteResponse && (
             <>
-              {urlInput(
-                "Display URL",
-                makeDisplayUrl(pasteResponse.url, encryptionKey),
-                <UrlTooltip
-                  desc={
-                    <>
-                      Browser-friendly view with syntax highlighting.
-                      {encryptionKey && (
-                        <>
-                          {" "}
-                          The decryption key sits after the <code className="font-mono">#</code> in the URL and is
-                          never sent to the server — it stays in the browser for client-side decryption.
-                        </>
-                      )}
-                    </>
-                  }
-                  flags={DISPLAY_URL_FLAGS}
-                />,
-                {
-                  color: encryptionKey ? "success" : "default",
-                  copyClassName: encryptionKey ? "bg-success-50 hover:bg-success-100" : "",
-                },
-              )}
+              {urlInput("Display URL", displayUrl, displayUrlLabelExtra, {
+                color: encryptionKey ? "success" : "default",
+                copyClassName: encryptionKey ? "bg-success-50 hover:bg-success-100" : "",
+                qrClassName: encryptionKey ? "hover:bg-success-100" : "hover:bg-default-200",
+              })}
               {isMarkdown && !isEncrypted && markdownUrlField(pasteResponse)}
               {urlInput(
                 "Raw URL",

--- a/frontend/components/UploadedPanel.tsx
+++ b/frontend/components/UploadedPanel.tsx
@@ -16,6 +16,7 @@ import {
 
 import type { PasteResponse } from "../../shared/interfaces.js"
 import { tst } from "../utils/overrides.js"
+import { makeDisplayUrl, withPathPrefix } from "../utils/pasteUrls.js"
 import type { UploadProgress } from "../utils/uploader.js"
 import { formatSize } from "../utils/utils.js"
 import { CopyWidget } from "./CopyWidget.js"
@@ -29,17 +30,6 @@ interface UploadedPanelProps extends CardProps {
   encryptionKey?: string
   highlightLang?: string
   isUrlPaste?: boolean
-}
-
-function withPathPrefix(url: string, prefix: string): string {
-  const u = new URL(url)
-  u.pathname = prefix + u.pathname
-  return u.toString()
-}
-
-function makeDecryptionUrl(url: string, key?: string): string {
-  const base = withPathPrefix(url, "/d")
-  return key ? `${base}#${key}` : base
 }
 
 const RAW_URL_FLAGS: { syntax: string; desc: string }[] = [
@@ -110,14 +100,31 @@ export function UploadedPanel({
   const isEncrypted = Boolean(encryptionKey)
   const isMarkdown = highlightLang === "markdown"
 
-  const urlInput = (label: string, value: string, labelExtra?: React.ReactNode) => (
-    <Input
-      {...inputProps}
-      label={label}
-      labelExtra={labelExtra}
-      value={value}
-      endContent={<CopyWidget className={copyWidgetClassNames} getCopyContent={() => value} />}
+  const copyLinkButton = (value: string, className = "") => (
+    <CopyWidget
+      label="Copy link"
+      className={`${copyWidgetClassNames} h-[38px] bg-default-100 ${className}`}
+      getCopyContent={() => value}
     />
+  )
+
+  const urlInput = (
+    label: string,
+    value: string,
+    labelExtra?: React.ReactNode,
+    options?: { color?: "default" | "success"; copyClassName?: string },
+  ) => (
+    <div className="mb-2 flex items-end gap-2">
+      <Input
+        {...inputProps}
+        className="mb-0 min-w-0 flex-1"
+        label={label}
+        labelExtra={labelExtra}
+        color={options?.color}
+        value={value}
+      />
+      {copyLinkButton(value, options?.copyClassName)}
+    </div>
   )
 
   const markdownUrlField = (pasteResponse: PasteResponse) =>
@@ -152,36 +159,29 @@ export function UploadedPanel({
         ) : (
           pasteResponse && (
             <>
-              <Input
-                {...inputProps}
-                label={"Display URL"}
-                labelExtra={
-                  <UrlTooltip
-                    desc={
-                      <>
-                        Browser-friendly view with syntax highlighting.
-                        {encryptionKey && (
-                          <>
-                            {" "}
-                            The decryption key sits after the <code className="font-mono">#</code> in the URL and is
-                            never sent to the server — it stays in the browser for client-side decryption.
-                          </>
-                        )}
-                      </>
-                    }
-                    flags={DISPLAY_URL_FLAGS}
-                  />
-                }
-                color={encryptionKey ? "success" : "default"}
-                className="mb-2"
-                value={makeDecryptionUrl(pasteResponse.url, encryptionKey)}
-                endContent={
-                  <CopyWidget
-                    className={encryptionKey ? `${copyWidgetClassNames} hover:bg-success-100` : copyWidgetClassNames}
-                    getCopyContent={() => makeDecryptionUrl(pasteResponse.url, encryptionKey)}
-                  />
-                }
-              />
+              {urlInput(
+                "Display URL",
+                makeDisplayUrl(pasteResponse.url, encryptionKey),
+                <UrlTooltip
+                  desc={
+                    <>
+                      Browser-friendly view with syntax highlighting.
+                      {encryptionKey && (
+                        <>
+                          {" "}
+                          The decryption key sits after the <code className="font-mono">#</code> in the URL and is
+                          never sent to the server — it stays in the browser for client-side decryption.
+                        </>
+                      )}
+                    </>
+                  }
+                  flags={DISPLAY_URL_FLAGS}
+                />,
+                {
+                  color: encryptionKey ? "success" : "default",
+                  copyClassName: encryptionKey ? "bg-success-50 hover:bg-success-100" : "",
+                },
+              )}
               {isMarkdown && !isEncrypted && markdownUrlField(pasteResponse)}
               {urlInput(
                 "Raw URL",

--- a/frontend/components/icons.tsx
+++ b/frontend/components/icons.tsx
@@ -76,7 +76,6 @@ export const CopyIcon = (props: HTMLAttributes<SVGElement>) => (
     viewBox="0 0 24 24"
     {...props}
   >
-    <path d="M0 0h24v24H0z" fill="none" />
     <path d="M20 2H10c-1 0-2 1-2 2v10c0 1 1 2 2 2h10c1 0 2-1 2-2V4c0-1-1-2-2-2zm0 12H10V4h10v10z" />
     <path d="M14 20H4V10h2V8H4c-1 0-2 1-2 2v10c0 1 1 2 2 2h10c1 0 2-1 2-2v-2h-2v2z" />
   </svg>
@@ -95,6 +94,17 @@ export const FileIcon = (props: HTMLAttributes<SVGElement>) => (
       <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
       <path d="M14 2v5a1 1 0 0 0 1 1h5" />
     </g>
+  </svg>
+)
+
+export const FolderIcon = (props: HTMLAttributes<SVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <path d="M4 20q-.825 0-1.412-.587T2 18V6q0-.825.588-1.412T4 4h6l2 2h8q.825 0 1.413.588T22 8v10q0 .825-.587 1.413T20 20zm0-2h16V8h-8.825l-2-2H4zm0 0V6z" />
   </svg>
 )
 
@@ -216,14 +226,8 @@ export const HomeIcon = (props: HTMLAttributes<SVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
     {...props}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
-    />
+    <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 12L12 1l11 11m-2-2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V10m6 12v-8h6v8" />
   </svg>
 )

--- a/frontend/components/icons.tsx
+++ b/frontend/components/icons.tsx
@@ -3,51 +3,40 @@ import type { HTMLAttributes } from "react"
 export const MoonIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="none"
+    fill="currentColor"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
     className="size-6 inline"
     {...props}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
-    />
+    <path d="M20.742 13.045a8.088 8.088 0 0 1-2.077.271c-2.135 0-4.14-.83-5.646-2.336a8.025 8.025 0 0 1-2.064-7.723A1 1 0 0 0 9.73 2.034a10.014 10.014 0 0 0-4.489 2.582c-3.898 3.898-3.898 10.243 0 14.143a9.937 9.937 0 0 0 7.072 2.93 9.93 9.93 0 0 0 7.07-2.929 10.007 10.007 0 0 0 2.583-4.491 1.001 1.001 0 0 0-1.224-1.224zm-2.772 4.301a7.947 7.947 0 0 1-5.656 2.343 7.953 7.953 0 0 1-5.658-2.344c-3.118-3.119-3.118-8.195 0-11.314a7.923 7.923 0 0 1 2.06-1.483 10.027 10.027 0 0 0 2.89 7.848 9.972 9.972 0 0 0 7.848 2.891 8.036 8.036 0 0 1-1.484 2.059z" />
   </svg>
 )
 
 export const SunIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="-2 -2 28 28"
-    strokeWidth={1.5}
-    stroke="currentColor"
+    fill="currentColor"
+    viewBox="0 0 24 24"
     {...props}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
-    />
+    <path d="M6.993 12c0 2.761 2.246 5.007 5.007 5.007s5.007-2.246 5.007-5.007S14.761 6.993 12 6.993 6.993 9.239 6.993 12zM12 8.993c1.658 0 3.007 1.349 3.007 3.007S13.658 15.007 12 15.007 8.993 13.658 8.993 12 10.342 8.993 12 8.993zM10.998 19h2v3h-2zm0-17h2v3h-2zm-9 9h3v2h-3zm17 0h3v2h-3zM4.219 18.363l2.12-2.122 1.415 1.414-2.12 2.122zM16.24 6.344l2.122-2.122 1.414 1.414-2.122 2.122zM6.342 7.759 4.22 5.637l1.415-1.414 2.12 2.122zm13.434 10.605-1.414 1.414-2.122-2.122 1.414-1.414z" />
   </svg>
 )
 
-export const ComputerIcon = (props: HTMLAttributes<SVGElement>) => (
+export const AutoThemeIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
     stroke="currentColor"
+    strokeWidth={2}
     {...props}
   >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9.173 14.83a4 4 0 1 1 5.657-5.657" />
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
-      d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25"
+      d="m11.294 12.707.174.247a7.5 7.5 0 0 0 8.845 2.492A9 9 0 0 1 5.642 18.36M3 12h1m8-9v1M5.6 5.6l.7.7M3 21 21 3"
     />
   </svg>
 )
@@ -72,34 +61,24 @@ export const XIcon = (props: HTMLAttributes<SVGElement>) => (
 export const DownloadIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="none"
+    fill="currentColor"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
     {...props}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="m9 13.5 3 3m0 0 3-3m-3 3v-6m1.06-4.19-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
-    />
+    <path d="M20 16a1 1 0 0 1 1 1v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-2a1 1 0 0 1 2 0v2a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2a1 1 0 0 1 1-1M12 3a1 1 0 0 1 1 1v9.585l3.293-3.292a1 1 0 0 1 1.414 1.414l-5 5a1 1 0 0 1-.09.08l.09-.08a1 1 0 0 1-.674.292L12 17h-.032l-.054-.004L12 17a1 1 0 0 1-.617-.213a1 1 0 0 1-.09-.08l-5-5a1 1 0 0 1 1.414-1.414L11 13.585V4a1 1 0 0 1 1-1" />
   </svg>
 )
 
 export const CopyIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="none"
+    fill="currentColor"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
     {...props}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
-    />
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M20 2H10c-1 0-2 1-2 2v10c0 1 1 2 2 2h10c1 0 2-1 2-2V4c0-1-1-2-2-2zm0 12H10V4h10v10z" />
+    <path d="M14 20H4V10h2V8H4c-1 0-2 1-2 2v10c0 1 1 2 2 2h10c1 0 2-1 2-2v-2h-2v2z" />
   </svg>
 )
 
@@ -108,15 +87,14 @@ export const FileIcon = (props: HTMLAttributes<SVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
     stroke="currentColor"
+    strokeWidth={2}
     {...props}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5A3.375 3.375 0 0 0 10.125 2.25H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
-    />
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+      <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+      <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+    </g>
   </svg>
 )
 
@@ -140,30 +118,22 @@ export const TrashIcon = (props: HTMLAttributes<SVGElement>) => (
 export const ExternalLinkIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="none"
+    fill="currentColor"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
     {...props}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
-    />
+    <path d="M7 6a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-3a1 1 0 1 1 2 0v3a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h3a1 1 0 1 1 0 2zM14 6a1 1 0 1 1 0-2h5a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0V7.414l-3.293 3.293a1 1 0 0 1-1.414-1.414L16.586 6z" />
   </svg>
 )
 
 export const CheckIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="none"
+    fill="currentColor"
     viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
     {...props}
   >
-    <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+    <path d="m9.55 18l-5.7-5.7l1.425-1.425L9.55 15.15l9.175-9.175L20.15 7.4z" />
   </svg>
 )
 
@@ -181,6 +151,18 @@ export const InfoIcon = (props: HTMLAttributes<SVGElement>) => (
       strokeLinejoin="round"
       d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
     />
+  </svg>
+)
+
+export const QrCodeIcon = (props: HTMLAttributes<SVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    strokeWidth={0}
+    {...props}
+  >
+    <path d="M3 11h8V3H3zm2-6h4v4H5zM3 21h8v-8H3zm2-6h4v4H5zm8-12v8h8V3zm6 6h-4V5h4zm0 10h2v2h-2zm-6-6h2v2h-2zm2 2h2v2h-2zm-2 2h2v2h-2zm2 2h2v2h-2zm2-2h2v2h-2zm0-4h2v2h-2zm2 2h2v2h-2z" />
   </svg>
 )
 

--- a/frontend/components/icons.tsx
+++ b/frontend/components/icons.tsx
@@ -22,7 +22,7 @@ export const SunIcon = (props: HTMLAttributes<SVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
-    viewBox="0 0 24 24"
+    viewBox="-2 -2 28 28"
     strokeWidth={1.5}
     stroke="currentColor"
     {...props}
@@ -99,6 +99,57 @@ export const CopyIcon = (props: HTMLAttributes<SVGElement>) => (
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+    />
+  </svg>
+)
+
+export const FileIcon = (props: HTMLAttributes<SVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5A3.375 3.375 0 0 0 10.125 2.25H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+    />
+  </svg>
+)
+
+export const TrashIcon = (props: HTMLAttributes<SVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673A2.25 2.25 0 0 1 15.916 21.75H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+    />
+  </svg>
+)
+
+export const ExternalLinkIcon = (props: HTMLAttributes<SVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
     />
   </svg>
 )

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -75,21 +75,21 @@ export function Input({
   return (
     <div className={`flex flex-col gap-1.5 min-w-0 ${className} ${classNames.base || ""}`}>
       {label && (
-        <label className={`pl-1 text-sm text-default-500 ${classNames.label || ""}`}>
+        <label className={`inline-flex w-fit items-center pl-1 text-sm text-default-500 ${classNames.label || ""}`}>
           {label}
-          {isRequired && <span className="text-red-500 ml-1">*</span>}
+          {isRequired && <span className="ml-1 text-red-500">*</span>}
           {labelExtra}
         </label>
       )}
       <div
-        className={`flex items-center ${boxBg} border rounded-xl color-tst ${borderColor} ${startContent || endContent || showClearButton ? "px-3" : ""} ${classNames.box || ""}`}
+        className={`flex items-center ${boxBg} border rounded-xl color-tst ${borderColor} ${startContent || endContent || showClearButton ? "pl-3 pr-1" : ""} ${classNames.box || ""}`}
       >
         {startContent && <div className="flex-shrink-0">{startContent}</div>}
         <input
           ref={inputRef}
           aria-label={label}
           aria-invalid={isInvalid}
-          className={`flex-1 py-2 bg-transparent text-sm text-foreground focus:outline-none color-tst ${startContent || endContent || showClearButton ? "" : "px-3"} ${classNames.input || ""}`}
+          className={`min-w-0 flex-1 py-2 bg-transparent text-sm text-foreground focus:outline-none color-tst ${startContent || endContent || showClearButton ? "" : "px-3"} ${classNames.input || ""}`}
           onChange={handleChange}
           value={value}
           {...rest}
@@ -106,7 +106,7 @@ export function Input({
             <XIcon className="w-4 h-4" />
           </button>
         )}
-        {endContent && <div className="flex-shrink-0">{endContent}</div>}
+        {endContent && <div className="inline-flex flex-shrink-0 items-center">{endContent}</div>}
       </div>
       {(description || errorMessage || warningMessage || successMessage) && (
         <div

--- a/frontend/components/ui/Tooltip.tsx
+++ b/frontend/components/ui/Tooltip.tsx
@@ -12,9 +12,10 @@ export interface TooltipProps {
   content: React.ReactNode
   children: React.ReactElement<TriggerProps>
   placement?: "auto" | "top" | "bottom"
+  contentClassName?: string
 }
 
-export function Tooltip({ content, children, placement = "auto" }: TooltipProps) {
+export function Tooltip({ content, children, placement = "auto", contentClassName }: TooltipProps) {
   const [show, setShow] = useState(false)
   const [position, setPosition] = useState<"top" | "bottom">("top")
   const [align, setAlign] = useState<"center" | "left" | "right">("center")
@@ -68,7 +69,7 @@ export function Tooltip({ content, children, placement = "auto" }: TooltipProps)
   return (
     <div
       ref={containerRef}
-      className={`relative inline-flex translate-y-[0.05em] ${show ? "z-50" : ""}`}
+      className={`relative inline-flex ${show ? "z-50" : ""}`}
       onKeyDown={(e) => {
         if (e.key === "Escape" && show) {
           setShow(false)
@@ -81,7 +82,9 @@ export function Tooltip({ content, children, placement = "auto" }: TooltipProps)
           ref={tooltipRef}
           id={tooltipId}
           role="tooltip"
-          className={`absolute z-50 px-2 py-1 text-sm bg-gray-800 text-white rounded shadow-lg w-max pointer-events-none ${
+          className={`absolute z-50 w-max pointer-events-none ${
+            contentClassName ?? "px-2 py-1 text-sm bg-gray-800 text-white rounded shadow-lg"
+          } ${
             position === "top" ? "bottom-full mb-2" : "top-full mt-2"
           } ${align === "center" ? "left-1/2 -translate-x-1/2" : align === "left" ? "left-0" : "right-0"}`}
         >

--- a/frontend/components/ui/Tooltip.tsx
+++ b/frontend/components/ui/Tooltip.tsx
@@ -11,9 +11,10 @@ interface TriggerProps {
 export interface TooltipProps {
   content: React.ReactNode
   children: React.ReactElement<TriggerProps>
+  placement?: "auto" | "top" | "bottom"
 }
 
-export function Tooltip({ content, children }: TooltipProps) {
+export function Tooltip({ content, children, placement = "auto" }: TooltipProps) {
   const [show, setShow] = useState(false)
   const [position, setPosition] = useState<"top" | "bottom">("top")
   const [align, setAlign] = useState<"center" | "left" | "right">("center")
@@ -27,7 +28,9 @@ export function Tooltip({ content, children }: TooltipProps) {
       const containerRect = containerRef.current.getBoundingClientRect()
 
       // Check vertical position
-      if (containerRect.top - tooltipRect.height - 8 < 0) {
+      if (placement !== "auto") {
+        setPosition(placement)
+      } else if (containerRect.top - tooltipRect.height - 8 < 0) {
         setPosition("bottom")
       } else {
         setPosition("top")
@@ -45,7 +48,7 @@ export function Tooltip({ content, children }: TooltipProps) {
         setAlign("center")
       }
     }
-  }, [show])
+  }, [placement, show])
 
   // Compose aria-describedby with whatever the child already had so we don't clobber.
   const existingDescribedBy = children.props["aria-describedby"]

--- a/frontend/components/ui/Tooltip.tsx
+++ b/frontend/components/ui/Tooltip.tsx
@@ -49,7 +49,18 @@ export function Tooltip({ content, children }: TooltipProps) {
 
   // Compose aria-describedby with whatever the child already had so we don't clobber.
   const existingDescribedBy = children.props["aria-describedby"]
-  const describedBy = existingDescribedBy ? `${existingDescribedBy} ${tooltipId}` : tooltipId
+  const triggerProps: TriggerProps = {
+    onMouseEnter: () => setShow(true),
+    onMouseLeave: () => setShow(false),
+    onFocus: () => setShow(true),
+    onBlur: () => setShow(false),
+  }
+
+  if (show) {
+    triggerProps["aria-describedby"] = existingDescribedBy ? `${existingDescribedBy} ${tooltipId}` : tooltipId
+  } else if (existingDescribedBy) {
+    triggerProps["aria-describedby"] = existingDescribedBy
+  }
 
   return (
     <div
@@ -61,13 +72,7 @@ export function Tooltip({ content, children }: TooltipProps) {
         }
       }}
     >
-      {React.cloneElement(children, {
-        onMouseEnter: () => setShow(true),
-        onMouseLeave: () => setShow(false),
-        onFocus: () => setShow(true),
-        onBlur: () => setShow(false),
-        "aria-describedby": describedBy,
-      })}
+      {React.cloneElement(children, triggerProps)}
       {show && (
         <div
           ref={tooltipRef}

--- a/frontend/pages/DisplayPaste.tsx
+++ b/frontend/pages/DisplayPaste.tsx
@@ -4,7 +4,7 @@ import { DisplayPasteView } from "./DisplayPasteView.js"
 import { parseFilenameFromContentDisposition, parsePath } from "../../shared/parsers.js"
 import { MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
 import { detectUtf8 } from "../../shared/encoding.js"
-import type { MetaResponse } from "../../shared/interfaces.js"
+import type { MetaResponse, OriginalFileInfo } from "../../shared/interfaces.js"
 import type { EncryptionScheme } from "../utils/encryption.js"
 import { decodeKey, decrypt } from "../utils/encryption.js"
 
@@ -20,6 +20,7 @@ interface InitialPasteState {
   guessedEncoding: string | null
   isDecrypted: "not encrypted" | "encrypted" | "decrypted"
   metaFilename?: string
+  originalFiles?: OriginalFileInfo[]
 }
 
 function getInitialPasteState(url: URL, name: string, ext: string | undefined, filename: string | undefined) {
@@ -45,6 +46,7 @@ function getInitialPasteState(url: URL, name: string, ext: string | undefined, f
     guessedEncoding: initialData.guessedEncoding,
     isDecrypted: scheme ? "encrypted" : "not encrypted",
     metaFilename: initialData.metadata.filename,
+    originalFiles: initialData.metadata.filenames,
   } satisfies InitialPasteState
 }
 
@@ -81,6 +83,7 @@ export function DisplayPaste({ config }: { config: Env }) {
     contentType: string
   } | null>(null)
   const [metaFilename, setMetaFilename] = useState<string | undefined>(initialPasteState.metaFilename)
+  const [originalFiles, setOriginalFiles] = useState<OriginalFileInfo[] | undefined>(initialPasteState.originalFiles)
 
   const { ErrorModal, showModal, handleFailedResp } = useErrorModal()
 
@@ -100,6 +103,12 @@ export function DisplayPaste({ config }: { config: Env }) {
       console.warn(`Failed to fetch metadata for ${name}`, e)
       return null
     }
+  }
+
+  function applyMetadata(metadata: MetaResponse | null, hasHeadFilename = false) {
+    if (!metadata) return
+    if (!hasHeadFilename && metadata.filename) setMetaFilename(metadata.filename)
+    if (metadata.filenames) setOriginalFiles(metadata.filenames)
   }
 
   const fetchPasteBody = useCallback(async () => {
@@ -201,9 +210,15 @@ export function DisplayPaste({ config }: { config: Env }) {
         }
         if (metaFilenameFromHead) setMetaFilename(metaFilenameFromHead)
 
-        const metadata = contentLength === null || !metaFilenameFromHead ? await fetchMetadata() : null
+        const shouldAwaitMetadata = contentLength === null
+        const metadataPromise = fetchMetadata()
+        const metadata = shouldAwaitMetadata ? await metadataPromise : null
+        applyMetadata(metadata, !!metaFilenameFromHead)
+        if (!shouldAwaitMetadata) {
+          void metadataPromise.then((metadata) => applyMetadata(metadata, true))
+        }
+
         const sizeBytes = contentLength ?? metadata?.sizeBytes ?? null
-        if (!metaFilenameFromHead && metadata?.filename) setMetaFilename(metadata.filename)
 
         const isText = effectiveContentType?.startsWith("text/") || !!contentLang
         const isMedia =
@@ -265,6 +280,7 @@ export function DisplayPaste({ config }: { config: Env }) {
         pendingInfo={pendingInfo}
         mediaInfo={mediaInfo}
         metaFilename={metaFilename}
+        originalFiles={originalFiles}
         onLoadAnyway={() => void fetchPasteBody()}
       />
       <ErrorModal />

--- a/frontend/pages/DisplayPaste.tsx
+++ b/frontend/pages/DisplayPaste.tsx
@@ -4,6 +4,7 @@ import { DisplayPasteView } from "./DisplayPasteView.js"
 import { parseFilenameFromContentDisposition, parsePath } from "../../shared/parsers.js"
 import { MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
 import { detectUtf8 } from "../../shared/encoding.js"
+import type { MetaResponse } from "../../shared/interfaces.js"
 import type { EncryptionScheme } from "../utils/encryption.js"
 import { decodeKey, decrypt } from "../utils/encryption.js"
 
@@ -11,31 +12,95 @@ import "../style.css"
 import "../styles/highlight-theme-light.css"
 import "../styles/highlight-theme-dark.css"
 
+interface InitialPasteState {
+  pasteFile?: File
+  pasteContentBuffer?: Uint8Array
+  pasteLang?: string
+  isFileBinary: boolean
+  guessedEncoding: string | null
+  isDecrypted: "not encrypted" | "encrypted" | "decrypted"
+  metaFilename?: string
+}
+
+function getInitialPasteState(url: URL, name: string, ext: string | undefined, filename: string | undefined) {
+  const initialData = window.__PASTE_DATA__
+  if (!initialData) {
+    return {
+      isFileBinary: false,
+      guessedEncoding: null,
+      isDecrypted: "not encrypted",
+    } satisfies InitialPasteState
+  }
+
+  const respBytes = Uint8Array.from(atob(initialData.content), (c) => c.charCodeAt(0))
+  const scheme = initialData.metadata.encryptionScheme as EncryptionScheme | undefined
+  const lang = url.searchParams.get("lang") || initialData.metadata.highlightLanguage
+  const inferredFilename = filename || (ext && name + ext) || initialData.metadata.filename
+
+  return {
+    pasteFile: new File([respBytes], inferredFilename || name),
+    pasteContentBuffer: respBytes,
+    pasteLang: lang || undefined,
+    isFileBinary: initialData.isBinary,
+    guessedEncoding: initialData.guessedEncoding,
+    isDecrypted: scheme ? "encrypted" : "not encrypted",
+    metaFilename: initialData.metadata.filename,
+  } satisfies InitialPasteState
+}
+
+function isMetaResponse(value: unknown): value is MetaResponse {
+  return typeof value === "object" && value !== null && typeof (value as MetaResponse).sizeBytes === "number"
+}
+
 export function DisplayPaste({ config }: { config: Env }) {
-  const [pasteFile, setPasteFile] = useState<File | undefined>(undefined)
-  const [pasteContentBuffer, setPasteContentBuffer] = useState<Uint8Array | undefined>(undefined)
-  const [pasteLang, setPasteLang] = useState<string | undefined>(undefined)
-  const [isFileBinary, setFileBinary] = useState(false)
-  const [guessedEncoding, setGuessedEncoding] = useState<string | null>(null)
-  const [isDecrypted, setDecrypted] = useState<"not encrypted" | "encrypted" | "decrypted">("not encrypted")
+  const url = new URL(location.toString())
+  const { name, ext, filename } = parsePath(url.pathname)
+  const pasteUrl = `/${name}`
+  const [initialPasteState] = useState(() => getInitialPasteState(url, name, ext, filename))
+
+  const [pasteFile, setPasteFile] = useState<File | undefined>(initialPasteState.pasteFile)
+  const [pasteContentBuffer, setPasteContentBuffer] = useState<Uint8Array | undefined>(
+    initialPasteState.pasteContentBuffer,
+  )
+  const [pasteLang, setPasteLang] = useState<string | undefined>(initialPasteState.pasteLang)
+  const [isFileBinary, setFileBinary] = useState(initialPasteState.isFileBinary)
+  const [guessedEncoding, setGuessedEncoding] = useState<string | null>(initialPasteState.guessedEncoding)
+  const [isDecrypted, setDecrypted] = useState<"not encrypted" | "encrypted" | "decrypted">(
+    initialPasteState.isDecrypted,
+  )
   const [forceShowBinary, setForceShowBinary] = useState(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [pendingInfo, setPendingInfo] = useState<{
-    sizeBytes: number
+    sizeBytes: number | null
     rawUrl: string
     contentType: string | null
   } | null>(null)
   const [mediaInfo, setMediaInfo] = useState<{
-    sizeBytes: number
+    sizeBytes: number | null
     rawUrl: string
     contentType: string
   } | null>(null)
-  const [metaFilename, setMetaFilename] = useState<string | undefined>(undefined)
+  const [metaFilename, setMetaFilename] = useState<string | undefined>(initialPasteState.metaFilename)
 
   const { ErrorModal, showModal, handleFailedResp } = useErrorModal()
-  const url = new URL(location.toString())
-  const { name, ext, filename } = parsePath(url.pathname)
-  const pasteUrl = `/${name}`
+
+  function parseContentLength(value: string | null): number | null {
+    if (value === null) return null
+    const parsed = Number(value)
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
+  }
+
+  async function fetchMetadata(): Promise<MetaResponse | null> {
+    try {
+      const resp = await fetch(`/m/${name}`)
+      if (!resp.ok) return null
+      const metadata: unknown = await resp.json()
+      return isMetaResponse(metadata) ? metadata : null
+    } catch (e) {
+      console.warn(`Failed to fetch metadata for ${name}`, e)
+      return null
+    }
+  }
 
   const fetchPasteBody = useCallback(async () => {
     setIsLoading(true)
@@ -107,21 +172,7 @@ export function DisplayPaste({ config }: { config: Env }) {
   }, [pasteUrl, name, ext, filename])
 
   useEffect(() => {
-    const initialData = window.__PASTE_DATA__
-
-    if (initialData) {
-      const respBytes = Uint8Array.from(atob(initialData.content), (c) => c.charCodeAt(0))
-      const scheme = initialData.metadata.encryptionScheme as EncryptionScheme | undefined
-      const lang = url.searchParams.get("lang") || initialData.metadata.highlightLanguage
-      const inferredFilename = filename || (ext && name + ext) || initialData.metadata.filename
-
-      setPasteLang(lang || undefined)
-      setPasteFile(new File([respBytes], inferredFilename || name))
-      setPasteContentBuffer(respBytes)
-      setFileBinary(initialData.isBinary)
-      setGuessedEncoding(initialData.guessedEncoding)
-      setDecrypted(scheme ? "encrypted" : "not encrypted")
-      if (initialData.metadata.filename) setMetaFilename(initialData.metadata.filename)
+    if (window.__PASTE_DATA__) {
       return
     }
 
@@ -134,8 +185,7 @@ export function DisplayPaste({ config }: { config: Env }) {
           return
         }
         const contentType = headResp.headers.get("Content-Type")
-        const contentLengthRaw = headResp.headers.get("Content-Length")
-        const contentLength = contentLengthRaw === null ? NaN : Number(contentLengthRaw)
+        const contentLength = parseContentLength(headResp.headers.get("Content-Length"))
         const contentLang = headResp.headers.get("X-PB-Highlight-Language")
         const scheme = headResp.headers.get("X-PB-Encryption-Scheme") as EncryptionScheme | null
         const decryptedContentType = headResp.headers.get("X-PB-Decrypted-Content-Type")
@@ -151,13 +201,17 @@ export function DisplayPaste({ config }: { config: Env }) {
         }
         if (metaFilenameFromHead) setMetaFilename(metaFilenameFromHead)
 
+        const metadata = contentLength === null || !metaFilenameFromHead ? await fetchMetadata() : null
+        const sizeBytes = contentLength ?? metadata?.sizeBytes ?? null
+        if (!metaFilenameFromHead && metadata?.filename) setMetaFilename(metadata.filename)
+
         const isText = effectiveContentType?.startsWith("text/") || !!contentLang
         const isMedia =
           effectiveContentType?.startsWith("image/") ||
           effectiveContentType?.startsWith("audio/") ||
           effectiveContentType?.startsWith("video/") ||
           false
-        const sizeOk = Number.isFinite(contentLength) && contentLength < MAX_AUTO_FETCH_BYTES
+        const sizeOk = sizeBytes !== null && sizeBytes < MAX_AUTO_FETCH_BYTES
 
         // text and encrypted media both need a GET + (maybe) decrypt before
         // rendering, so they share fetchPasteBody. Plain media can be rendered
@@ -172,14 +226,14 @@ export function DisplayPaste({ config }: { config: Env }) {
         }
         if (isMedia && !isEncrypted) {
           setMediaInfo({
-            sizeBytes: Number.isFinite(contentLength) ? contentLength : 0,
+            sizeBytes,
             rawUrl: pasteUrl,
             contentType: effectiveContentType!,
           })
           return
         }
         setPendingInfo({
-          sizeBytes: Number.isFinite(contentLength) ? contentLength : 0,
+          sizeBytes,
           rawUrl: pasteUrl,
           contentType: effectiveContentType,
         })

--- a/frontend/pages/DisplayPaste.tsx
+++ b/frontend/pages/DisplayPaste.tsx
@@ -23,6 +23,15 @@ interface InitialPasteState {
   originalFiles?: OriginalFileInfo[]
 }
 
+interface FetchedPasteFile {
+  file: File
+  content: Uint8Array
+  filenameFromDisp?: string
+  lang?: string
+  scheme: EncryptionScheme | null
+  didDecrypt: boolean
+}
+
 function getInitialPasteState(url: URL, name: string, ext: string | undefined, filename: string | undefined) {
   const initialData = window.__PASTE_DATA__
   if (!initialData) {
@@ -52,6 +61,10 @@ function getInitialPasteState(url: URL, name: string, ext: string | undefined, f
 
 function isMetaResponse(value: unknown): value is MetaResponse {
   return typeof value === "object" && value !== null && typeof (value as MetaResponse).sizeBytes === "number"
+}
+
+function stripEncryptedSuffix(filename: string | undefined): string | undefined {
+  return filename?.replace(/\.encrypted$/, "")
 }
 
 export function DisplayPaste({ config }: { config: Env }) {
@@ -111,74 +124,108 @@ export function DisplayPaste({ config }: { config: Env }) {
     if (metadata.filenames) setOriginalFiles(metadata.filenames)
   }
 
-  const fetchPasteBody = useCallback(async () => {
-    setIsLoading(true)
-    setPendingInfo(null)
-    setMediaInfo(null)
+  function triggerDownload(file: File) {
+    const downloadBlob =
+      file.type === "application/octet-stream" ? file : new Blob([file], { type: "application/octet-stream" })
+    const url = URL.createObjectURL(downloadBlob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = file.name
+    link.style.display = "none"
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    window.setTimeout(() => {
+      if (URL.revokeObjectURL) URL.revokeObjectURL(url)
+    }, 0)
+  }
+
+  const fetchPasteFile = useCallback(async (): Promise<FetchedPasteFile | null> => {
     try {
       const resp = await fetch(pasteUrl)
       if (!resp.ok) {
         await handleFailedResp("Failed to Fetch Paste", resp)
-        return
+        return null
       }
       const scheme: EncryptionScheme | null = resp.headers.get("X-PB-Encryption-Scheme") as EncryptionScheme | null
       let filenameFromDisp = resp.headers.has("Content-Disposition")
         ? parseFilenameFromContentDisposition(resp.headers.get("Content-Disposition")!) || undefined
         : undefined
       if (filenameFromDisp && scheme !== null) {
-        filenameFromDisp = filenameFromDisp.replace(/\.encrypted$/, "")
+        filenameFromDisp = stripEncryptedSuffix(filenameFromDisp)
       }
       const lang = url.searchParams.get("lang") || resp.headers.get("X-PB-Highlight-Language")
-      const inferredFilename = filename || (ext && name + ext) || filenameFromDisp
+      let metadataFilename = metaFilename
+      if (!filename && !ext && !filenameFromDisp && !metadataFilename) {
+        metadataFilename = stripEncryptedSuffix((await fetchMetadata())?.filename)
+      }
+      const inferredFilename = filename || (ext && name + ext) || filenameFromDisp || metadataFilename
       const decryptedContentType = resp.headers.get("X-PB-Decrypted-Content-Type")
       const blobMime = (scheme ? decryptedContentType : resp.headers.get("Content-Type"))?.split(";")[0]?.trim() || ""
       const respBytes = await resp.bytes()
-      setPasteLang(lang || undefined)
-      if (filenameFromDisp) setMetaFilename(filenameFromDisp)
 
       const keyString = url.hash.slice(1)
       if (scheme === null || keyString.length === 0) {
-        setPasteFile(new File([respBytes as BlobPart], inferredFilename || name, { type: blobMime }))
-        setPasteContentBuffer(respBytes)
-        if (scheme) {
-          setDecrypted("encrypted")
-          setFileBinary(true)
-        } else {
-          const encoding = detectUtf8(respBytes)
-          setFileBinary(encoding === null)
-          setGuessedEncoding(encoding)
-        }
-      } else {
-        let key: CryptoKey
-        try {
-          key = await decodeKey(scheme, keyString)
-        } catch (err) {
-          showModal("Invalid decryption key", (err as Error).message)
-          return
-        }
-        const decrypted = await decrypt(scheme, key, respBytes)
-        if (!decrypted) {
-          showModal(
-            "Decryption failed",
-            "Could not decrypt the paste with the provided key. The URL fragment may be wrong, " +
-              "or the paste has been replaced or corrupted.",
-          )
-          return
-        }
-        setPasteFile(new File([decrypted as BlobPart], inferredFilename || name, { type: blobMime }))
-        setPasteContentBuffer(decrypted)
-        const encoding = detectUtf8(decrypted)
-        setFileBinary(encoding === null)
-        setDecrypted("decrypted")
-        setGuessedEncoding(encoding)
+        const file = new File([respBytes as BlobPart], inferredFilename || name, { type: blobMime })
+        return { file, content: respBytes, filenameFromDisp, lang: lang || undefined, scheme, didDecrypt: false }
       }
+
+      let key: CryptoKey
+      try {
+        key = await decodeKey(scheme, keyString)
+      } catch (err) {
+        showModal("Invalid decryption key", (err as Error).message)
+        return null
+      }
+      const decrypted = await decrypt(scheme, key, respBytes)
+      if (!decrypted) {
+        showModal(
+          "Decryption failed",
+          "Could not decrypt the paste with the provided key. The URL fragment may be wrong, " +
+            "or the paste has been replaced or corrupted.",
+        )
+        return null
+      }
+      const file = new File([decrypted as BlobPart], inferredFilename || name, { type: blobMime })
+      return { file, content: decrypted, filenameFromDisp, lang: lang || undefined, scheme, didDecrypt: true }
     } catch (e) {
       showModal(`Error on fetching ${pasteUrl}`, (e as Error).toString())
       console.error(e)
+      return null
+    }
+  }, [pasteUrl, name, ext, filename, metaFilename])
+
+  const fetchPasteBody = useCallback(async () => {
+    setIsLoading(true)
+    setPendingInfo(null)
+    setMediaInfo(null)
+    try {
+      const paste = await fetchPasteFile()
+      if (!paste) return
+
+      setPasteLang(paste.lang)
+      if (paste.filenameFromDisp) setMetaFilename(paste.filenameFromDisp)
+      setPasteFile(paste.file)
+      setPasteContentBuffer(paste.content)
+      if (paste.scheme) {
+        setDecrypted(paste.didDecrypt ? "decrypted" : "encrypted")
+      }
+      if (paste.scheme && !paste.didDecrypt) {
+        setFileBinary(true)
+      } else {
+        const encoding = detectUtf8(paste.content)
+        setFileBinary(encoding === null)
+        setGuessedEncoding(encoding)
+      }
     } finally {
       setIsLoading(false)
     }
-  }, [pasteUrl, name, ext, filename])
+  }, [fetchPasteFile])
+
+  const downloadPasteBody = useCallback(async () => {
+    const paste = await fetchPasteFile()
+    if (paste) triggerDownload(paste.file)
+  }, [fetchPasteFile])
 
   useEffect(() => {
     if (window.__PASTE_DATA__) {
@@ -201,12 +248,13 @@ export function DisplayPaste({ config }: { config: Env }) {
         const contentDisp = headResp.headers.get("Content-Disposition")
         const isEncrypted = scheme !== null
         const effectiveContentType = isEncrypted ? decryptedContentType : contentType
+        setDecrypted(isEncrypted ? "encrypted" : "not encrypted")
 
         let metaFilenameFromHead = contentDisp
           ? parseFilenameFromContentDisposition(contentDisp) || undefined
           : undefined
         if (metaFilenameFromHead && isEncrypted) {
-          metaFilenameFromHead = metaFilenameFromHead.replace(/\.encrypted$/, "")
+          metaFilenameFromHead = stripEncryptedSuffix(metaFilenameFromHead)
         }
         if (metaFilenameFromHead) setMetaFilename(metaFilenameFromHead)
 
@@ -215,7 +263,7 @@ export function DisplayPaste({ config }: { config: Env }) {
         const metadata = shouldAwaitMetadata ? await metadataPromise : null
         applyMetadata(metadata, !!metaFilenameFromHead)
         if (!shouldAwaitMetadata) {
-          void metadataPromise.then((metadata) => applyMetadata(metadata, true))
+          void metadataPromise.then((metadata) => applyMetadata(metadata, !!metaFilenameFromHead))
         }
 
         const sizeBytes = contentLength ?? metadata?.sizeBytes ?? null
@@ -282,6 +330,9 @@ export function DisplayPaste({ config }: { config: Env }) {
         metaFilename={metaFilename}
         originalFiles={originalFiles}
         onLoadAnyway={() => void fetchPasteBody()}
+        onDownloadPaste={
+          isDecrypted === "encrypted" && url.hash.slice(1).length > 0 ? () => void downloadPasteBody() : undefined
+        }
       />
       <ErrorModal />
     </>

--- a/frontend/pages/DisplayPaste.tsx
+++ b/frontend/pages/DisplayPaste.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useErrorModal } from "../components/ErrorModal.js"
 import { DisplayPasteView } from "./DisplayPasteView.js"
 import { parseFilenameFromContentDisposition, parsePath } from "../../shared/parsers.js"
@@ -85,6 +85,9 @@ export function DisplayPaste({ config }: { config: Env }) {
   )
   const [forceShowBinary, setForceShowBinary] = useState(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isDownloading, setIsDownloading] = useState<boolean>(false)
+  const isFetchingBodyRef = useRef(false)
+  const isDownloadingRef = useRef(false)
   const [pendingInfo, setPendingInfo] = useState<{
     sizeBytes: number | null
     rawUrl: string
@@ -196,6 +199,8 @@ export function DisplayPaste({ config }: { config: Env }) {
   }, [pasteUrl, name, ext, filename, metaFilename])
 
   const fetchPasteBody = useCallback(async () => {
+    if (isFetchingBodyRef.current) return
+    isFetchingBodyRef.current = true
     setIsLoading(true)
     setPendingInfo(null)
     setMediaInfo(null)
@@ -218,13 +223,22 @@ export function DisplayPaste({ config }: { config: Env }) {
         setGuessedEncoding(encoding)
       }
     } finally {
+      isFetchingBodyRef.current = false
       setIsLoading(false)
     }
   }, [fetchPasteFile])
 
   const downloadPasteBody = useCallback(async () => {
-    const paste = await fetchPasteFile()
-    if (paste) triggerDownload(paste.file)
+    if (isDownloadingRef.current) return
+    isDownloadingRef.current = true
+    setIsDownloading(true)
+    try {
+      const paste = await fetchPasteFile()
+      if (paste) triggerDownload(paste.file)
+    } finally {
+      isDownloadingRef.current = false
+      setIsDownloading(false)
+    }
   }, [fetchPasteFile])
 
   useEffect(() => {
@@ -321,6 +335,7 @@ export function DisplayPaste({ config }: { config: Env }) {
         forceShowBinary={forceShowBinary}
         setForceShowBinary={setForceShowBinary}
         isLoading={isLoading}
+        isDownloading={isDownloading}
         name={name}
         ext={ext}
         filename={filename}

--- a/frontend/pages/DisplayPaste.tsx
+++ b/frontend/pages/DisplayPaste.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useErrorModal } from "../components/ErrorModal.js"
 import { DisplayPasteView } from "./DisplayPasteView.js"
 import { parseFilenameFromContentDisposition, parsePath } from "../../shared/parsers.js"
-import { MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
+import { BINARY_MIME_TYPE, MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
 import { detectUtf8 } from "../../shared/encoding.js"
 import type { MetaResponse, OriginalFileInfo } from "../../shared/interfaces.js"
 import type { EncryptionScheme } from "../utils/encryption.js"
@@ -128,8 +128,7 @@ export function DisplayPaste({ config }: { config: Env }) {
   }
 
   function triggerDownload(file: File) {
-    const downloadBlob =
-      file.type === "application/octet-stream" ? file : new Blob([file], { type: "application/octet-stream" })
+    const downloadBlob = file.type === BINARY_MIME_TYPE ? file : new Blob([file], { type: BINARY_MIME_TYPE })
     const url = URL.createObjectURL(downloadBlob)
     const link = document.createElement("a")
     link.href = url

--- a/frontend/pages/DisplayPasteView.tsx
+++ b/frontend/pages/DisplayPasteView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { CircularProgress, Link, Tooltip } from "../components/ui/index.js"
 import { DarkModeToggle, useDarkModeSelection } from "../components/DarkModeToggle.js"
 import { DownloadIcon, HomeIcon } from "../components/icons.js"
@@ -9,6 +9,8 @@ import { highlightHTML, useHljsForLang } from "../utils/highlight.js"
 import { formatSize } from "../utils/utils.js"
 import type { OriginalFileInfo } from "../../shared/interfaces.js"
 import { filenameForTitle } from "../../shared/filename.js"
+import { FileTree } from "../components/FileTree.js"
+import { itemCountLabel } from "../../shared/format.js"
 
 interface PendingInfo {
   sizeBytes: number | null
@@ -61,15 +63,16 @@ function sizeSuffix(sizeBytes: number | null): string {
   return sizeBytes === null ? "" : ` (${formatSize(sizeBytes)})`
 }
 
-function OriginalFileList({ files }: { files: OriginalFileInfo[] }) {
+function OriginalFileList({
+  files,
+  className = "mt-2 mb-2 max-h-48 w-full max-w-[32rem] overflow-auto text-left",
+}: {
+  files: OriginalFileInfo[]
+  className?: string
+}) {
   return (
-    <div className="mt-2 w-full max-w-[32rem] text-sm">
-      {files.map((file, index) => (
-        <div key={`${file.name}-${index}`} className="flex justify-between gap-4 text-left">
-          <span className="truncate">{file.name}</span>
-          <span className="shrink-0 text-foreground-500">{formatSize(file.sizeBytes)}</span>
-        </div>
-      ))}
+    <div className={className}>
+      <FileTree files={files} />
     </div>
   )
 }
@@ -95,6 +98,7 @@ interface DisplayPasteViewProps {
   forceShowBinary: boolean
   setForceShowBinary: (v: boolean) => void
   isLoading: boolean
+  isDownloading: boolean
   name: string
   ext?: string
   filename?: string
@@ -118,6 +122,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
     forceShowBinary,
     setForceShowBinary,
     isLoading,
+    isDownloading,
     name,
     ext,
     filename,
@@ -136,10 +141,21 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   const hljs = useHljsForLang(pasteLang)
   const [downloadUrl, setDownloadUrl] = useState<string>("#")
   const [displayUrl, setDisplayUrl] = useState<string>("")
+  const [isNativeDownloadDebounced, setNativeDownloadDebounced] = useState(false)
+  const nativeDownloadDebouncedRef = useRef(false)
+  const nativeDownloadDebounceTimer = useRef<number | undefined>(undefined)
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       setDisplayUrl(window.location.href)
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (nativeDownloadDebounceTimer.current !== undefined) {
+        window.clearTimeout(nativeDownloadDebounceTimer.current)
+      }
     }
   }, [])
 
@@ -162,16 +178,40 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   const pasteLineCount = (highlightedHTML?.match(/\n/g)?.length || 0) + 1
   const hasOriginalFiles = originalFiles !== undefined && originalFiles.length > 0
   const isZipArchive = isZipBuffer(pasteContentBuffer)
+  const isDownloadActionDisabled = isLoading || isDownloading
+
+  function onNativeDownloadClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    if (nativeDownloadDebouncedRef.current) {
+      e.preventDefault()
+      return
+    }
+    nativeDownloadDebouncedRef.current = true
+    setNativeDownloadDebounced(true)
+    if (nativeDownloadDebounceTimer.current !== undefined) {
+      window.clearTimeout(nativeDownloadDebounceTimer.current)
+    }
+    nativeDownloadDebounceTimer.current = window.setTimeout(() => {
+      nativeDownloadDebouncedRef.current = false
+      setNativeDownloadDebounced(false)
+      nativeDownloadDebounceTimer.current = undefined
+    }, 1000)
+  }
 
   const binaryFileIndicator = pasteFile && (
-    <div className="absolute top-[50%] left-[50%] translate-[-50%] flex flex-col items-center w-full">
-      <div className="text-foreground-600 mb-2">{`${hasOriginalFiles ? `${originalFiles.length} files` : pasteFile?.name} (${formatSize(pasteFile.size)})`}</div>
+    <div className="flex min-h-[10em] w-full flex-col items-center justify-center px-4">
+      <div className="text-foreground-600 mb-2">{`${hasOriginalFiles ? itemCountLabel(originalFiles.length) : pasteFile?.name} (${formatSize(pasteFile.size)})`}</div>
       {hasOriginalFiles && <OriginalFileList files={originalFiles} />}
       <div className="w-fit text-center">
         {isZipArchive ? (
           <>
             Not a renderable file (application/zip).{" "}
-            <a href={downloadUrl} download={pasteFile.name} className="text-primary inline">
+            <a
+              href={downloadUrl}
+              download={pasteFile.name}
+              className={`text-primary inline ${isNativeDownloadDebounced ? "pointer-events-none opacity-50" : ""}`}
+              aria-disabled={isNativeDownloadDebounced}
+              onClick={onNativeDownloadClick}
+            >
               Download raw
             </a>
           </>
@@ -187,9 +227,9 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
     </div>
   )
 
-  const contentDisplayFilename = hasOriginalFiles ? `${originalFiles.length} files` : filename || metaFilename
+  const contentDisplayFilename = hasOriginalFiles ? itemCountLabel(originalFiles.length) : filename || metaFilename
   const titleDisplayFilename = hasOriginalFiles
-    ? `${originalFiles.length} files`
+    ? itemCountLabel(originalFiles.length)
     : filenameForTitle(filename || metaFilename)
   const placeholderName = contentDisplayFilename || (ext ? name + ext : name)
   const rawDownloadUrl = pendingInfo || mediaInfo ? `${(pendingInfo ?? mediaInfo)!.rawUrl}?a` : "#"
@@ -207,25 +247,38 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
     return "Paste is too large to load automatically."
   })()
   const pendingFileIndicator = pendingInfo && !pasteFile && (
-    <div className="absolute top-[50%] left-[50%] translate-[-50%] flex flex-col items-center w-full px-4">
+    <div className="flex min-h-[10em] w-full flex-col items-center justify-center px-4">
       <div className="text-foreground-600 mb-2">{`${placeholderName}${sizeSuffix(pendingInfo.sizeBytes)}`}</div>
       {hasOriginalFiles && <OriginalFileList files={originalFiles} />}
       <div className="w-fit text-center">
         {placeholderReason}{" "}
         {onDownloadPaste ? (
-          <button className="text-primary inline cursor-pointer" onClick={() => onDownloadPaste()}>
-            Download decrypted
+          <button
+            className="text-primary inline cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={isDownloadActionDisabled}
+            onClick={() => onDownloadPaste()}
+          >
+            {isDownloading ? "Downloading..." : "Download decrypted"}
           </button>
         ) : (
-          <Link href={`${pendingInfo.rawUrl}?a`} className="text-primary inline">
+          <Link
+            href={`${pendingInfo.rawUrl}?a`}
+            className={`text-primary inline ${isNativeDownloadDebounced ? "pointer-events-none opacity-50" : ""}`}
+            aria-disabled={isNativeDownloadDebounced}
+            onClick={onNativeDownloadClick}
+          >
             Download raw
           </Link>
         )}
         {onLoadAnyway && (
           <>
             {" or "}
-            <button className="text-primary inline cursor-pointer" onClick={() => onLoadAnyway()}>
-              load anyway
+            <button
+              className="text-primary inline cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={isLoading}
+              onClick={() => onLoadAnyway()}
+            >
+              {isLoading ? "loading..." : "load anyway"}
             </button>
             .
           </>
@@ -237,6 +290,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   const lineNumOffset = `${Math.floor(Math.log10(pasteLineCount)) + 3}ch`
   const buttonClasses = `${tst}`
   const iconLinkClass = `inline-flex items-center justify-center rounded-full p-1.5 text-default-600 hover:bg-default-100 cursor-pointer ${buttonClasses}`
+  const disabledIconClass = "disabled:cursor-not-allowed disabled:opacity-50"
 
   return (
     <main
@@ -244,12 +298,8 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
     >
       <div className="w-full max-w-[64rem]">
         <div className="flex flex-row my-4 items-center justify-between">
-          <h1 className="text-xl md:text-2xl grow inline-flex items-baseline min-w-0">
-            <a
-              href="/"
-              aria-label={indexPageTitle}
-              className={`${iconLinkClass} md:hidden shrink-0`}
-            >
+          <h1 className="text-xl md:text-2xl grow inline-flex items-center md:items-baseline min-w-0">
+            <a href="/" aria-label={indexPageTitle} className={`${iconLinkClass} md:hidden shrink-0`}>
               <HomeIcon className="size-6" />
             </a>
             <Link href="/" className="text-foreground-500 text-[length:inherited] shrink-0 hidden md:inline">
@@ -281,7 +331,14 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
             )}
             {pasteFile ? (
               <Tooltip content={`Download as file`}>
-                <a href={downloadUrl} download={pasteFile.name} aria-label="Download" className={iconLinkClass}>
+                <a
+                  href={downloadUrl}
+                  download={pasteFile.name}
+                  aria-label="Download"
+                  className={`${iconLinkClass} ${isNativeDownloadDebounced ? "pointer-events-none opacity-50" : ""}`}
+                  aria-disabled={isNativeDownloadDebounced}
+                  onClick={onNativeDownloadClick}
+                >
                   <DownloadIcon className="size-6 inline" />
                 </a>
               </Tooltip>
@@ -293,12 +350,20 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
                       type="button"
                       onClick={() => onDownloadPaste()}
                       aria-label="Download"
-                      className={iconLinkClass}
+                      disabled={isDownloadActionDisabled}
+                      className={`${iconLinkClass} ${disabledIconClass}`}
                     >
                       <DownloadIcon className="size-6 inline" />
                     </button>
                   ) : (
-                    <a href={rawDownloadUrl} download={placeholderName} aria-label="Download" className={iconLinkClass}>
+                    <a
+                      href={rawDownloadUrl}
+                      download={placeholderName}
+                      aria-label="Download"
+                      className={`${iconLinkClass} ${isNativeDownloadDebounced ? "pointer-events-none opacity-50" : ""}`}
+                      aria-disabled={isNativeDownloadDebounced}
+                      onClick={onNativeDownloadClick}
+                    >
                       <DownloadIcon className="size-6 inline" />
                     </a>
                   )}
@@ -336,10 +401,10 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
                 <MediaElement kind={pasteMediaKind} src={downloadUrl} name={pasteFile.name} />
               </div>
             ) : pendingInfo && !pasteFile ? (
-              <div className={"h-[10em]"}>{pendingFileIndicator}</div>
+              pendingFileIndicator
             ) : (
               pasteFile && (
-                <div className={showFileContent ? "" : "h-[10em]"}>
+                <div>
                   {showFileContent ? (
                     <>
                       <div className="text-gray-500 mb-2 text-sm flex flex-row gap-2">

--- a/frontend/pages/DisplayPasteView.tsx
+++ b/frontend/pages/DisplayPasteView.tsx
@@ -6,6 +6,8 @@ import { CopyWidget } from "../components/CopyWidget.js"
 import { tst } from "../utils/overrides.js"
 import { highlightHTML, useHljsForLang } from "../utils/highlight.js"
 import { formatSize } from "../utils/utils.js"
+import type { OriginalFileInfo } from "../../shared/interfaces.js"
+import { filenameForTitle } from "../../shared/filename.js"
 
 interface PendingInfo {
   sizeBytes: number | null
@@ -58,6 +60,30 @@ function sizeSuffix(sizeBytes: number | null): string {
   return sizeBytes === null ? "" : ` (${formatSize(sizeBytes)})`
 }
 
+function OriginalFileList({ files }: { files: OriginalFileInfo[] }) {
+  return (
+    <div className="mt-2 w-full max-w-[32rem] text-sm">
+      {files.map((file, index) => (
+        <div key={`${file.name}-${index}`} className="flex justify-between gap-4 text-left">
+          <span className="truncate">{file.name}</span>
+          <span className="shrink-0 text-foreground-500">{formatSize(file.sizeBytes)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const zipSignatures = [
+  [0x50, 0x4b, 0x03, 0x04],
+  [0x50, 0x4b, 0x05, 0x06],
+  [0x50, 0x4b, 0x07, 0x08],
+] as const
+
+function isZipBuffer(buffer: Uint8Array | undefined): boolean {
+  if (!buffer || buffer.length < 4) return false
+  return zipSignatures.some((signature) => signature.every((byte, index) => buffer[index] === byte))
+}
+
 interface DisplayPasteViewProps {
   pasteFile?: File
   pasteContentBuffer?: Uint8Array
@@ -75,6 +101,7 @@ interface DisplayPasteViewProps {
   pendingInfo?: PendingInfo | null
   mediaInfo?: MediaInfo | null
   metaFilename?: string
+  originalFiles?: OriginalFileInfo[]
   onLoadAnyway?: () => void
 }
 
@@ -96,6 +123,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
     pendingInfo,
     mediaInfo,
     metaFilename,
+    originalFiles,
     onLoadAnyway,
   } = props
 
@@ -122,21 +150,36 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   const pasteStringContent = pasteContentBuffer && new TextDecoder().decode(pasteContentBuffer)
   const highlightedHTML = pasteStringContent ? highlightHTML(hljs, pasteLang, pasteStringContent) : ""
   const pasteLineCount = (highlightedHTML?.match(/\n/g)?.length || 0) + 1
+  const hasOriginalFiles = originalFiles !== undefined && originalFiles.length > 0
+  const isZipArchive = isZipBuffer(pasteContentBuffer)
 
   const binaryFileIndicator = pasteFile && (
     <div className="absolute top-[50%] left-[50%] translate-[-50%] flex flex-col items-center w-full">
-      <div className="text-foreground-600 mb-2">{`${pasteFile?.name} (${formatSize(pasteFile.size)})`}</div>
+      <div className="text-foreground-600 mb-2">{`${hasOriginalFiles ? `${originalFiles.length} files` : pasteFile?.name} (${formatSize(pasteFile.size)})`}</div>
+      {hasOriginalFiles && <OriginalFileList files={originalFiles} />}
       <div className="w-fit text-center">
-        This file seems to be binary or not in UTF-8{guessedEncoding ? ` (${guessedEncoding} guessed). ` : ". "}
-        <button className="text-primary-500 inline" onClick={() => setForceShowBinary(true)}>
-          (Click to show)
-        </button>
+        {isZipArchive ? (
+          <>
+            Not a renderable file (application/zip).{" "}
+            <a href={downloadUrl} download={pasteFile.name} className="text-primary-500 inline">
+              Download raw
+            </a>
+          </>
+        ) : (
+          <>
+            This file seems to be binary or not in UTF-8{guessedEncoding ? ` (${guessedEncoding} guessed). ` : ". "}
+            <button className="text-primary-500 inline" onClick={() => setForceShowBinary(true)}>
+              (Click to show)
+            </button>
+          </>
+        )}
       </div>
     </div>
   )
 
-  const displayFilename = filename || metaFilename
-  const placeholderName = displayFilename || (ext ? name + ext : name)
+  const contentDisplayFilename = hasOriginalFiles ? `${originalFiles.length} files` : filename || metaFilename
+  const titleDisplayFilename = hasOriginalFiles ? `${originalFiles.length} files` : filenameForTitle(filename || metaFilename)
+  const placeholderName = contentDisplayFilename || (ext ? name + ext : name)
   const placeholderReason = (() => {
     if (!pendingInfo) return ""
     const ct = pendingInfo.contentType
@@ -153,6 +196,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   const pendingFileIndicator = pendingInfo && !pasteFile && (
     <div className="absolute top-[50%] left-[50%] translate-[-50%] flex flex-col items-center w-full px-4">
       <div className="text-foreground-600 mb-2">{`${placeholderName}${sizeSuffix(pendingInfo.sizeBytes)}`}</div>
+      {hasOriginalFiles && <OriginalFileList files={originalFiles} />}
       <div className="w-fit text-center">
         {placeholderReason}{" "}
         <Link href={`${pendingInfo.rawUrl}?a`} className="text-primary-500 inline">
@@ -193,12 +237,12 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
               {indexPageTitle}
             </Link>
             <span className="mx-2 shrink-0">{" / "}</span>
-            <span className="shrink-0">{displayFilename ? name : name + (ext ?? "")}</span>
-            {displayFilename && (
+            <span className="shrink-0">{titleDisplayFilename ? name : name + (ext ?? "")}</span>
+            {titleDisplayFilename && (
               <>
                 <span className="mx-2 shrink-0">{" / "}</span>
-                <span className="truncate min-w-0" title={displayFilename}>
-                  {displayFilename}
+                <span className="truncate min-w-0" title={titleDisplayFilename}>
+                  {titleDisplayFilename}
                 </span>
               </>
             )}
@@ -252,9 +296,10 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
             ) : pasteFile && pasteMediaKind ? (
               <div>
                 <div className="text-gray-500 mb-2 text-sm flex flex-row gap-2">
-                  <span>{pasteFile.name}</span>
+                  <span>{contentDisplayFilename || pasteFile.name}</span>
                   <span>{`(${formatSize(pasteFile.size)})`}</span>
                 </div>
+                {hasOriginalFiles && <OriginalFileList files={originalFiles} />}
                 <MediaElement kind={pasteMediaKind} src={downloadUrl} name={pasteFile.name} />
               </div>
             ) : pendingInfo && !pasteFile ? (
@@ -265,7 +310,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
                   {showFileContent ? (
                     <>
                       <div className="text-gray-500 mb-2 text-sm flex flex-row gap-2">
-                        <span>{pasteFile?.name}</span>
+                        <span>{contentDisplayFilename || pasteFile?.name}</span>
                         <span>{`(${formatSize(pasteFile.size)})`}</span>
                         {forceShowBinary && (
                           <button className="ml-2 text-primary-500" onClick={() => setForceShowBinary(false)}>
@@ -274,6 +319,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
                         )}
                         {pasteLang && <span className={"grow text-right"}>{pasteLang}</span>}
                       </div>
+                      {hasOriginalFiles && <OriginalFileList files={originalFiles} />}
                       <div className="font-mono relative" role="article">
                         <pre
                           style={{ marginLeft: lineNumOffset, width: `calc(100% - ${lineNumOffset})` }}

--- a/frontend/pages/DisplayPasteView.tsx
+++ b/frontend/pages/DisplayPasteView.tsx
@@ -103,6 +103,7 @@ interface DisplayPasteViewProps {
   metaFilename?: string
   originalFiles?: OriginalFileInfo[]
   onLoadAnyway?: () => void
+  onDownloadPaste?: () => void
 }
 
 export function DisplayPasteView(props: DisplayPasteViewProps) {
@@ -125,6 +126,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
     metaFilename,
     originalFiles,
     onLoadAnyway,
+    onDownloadPaste,
   } = props
 
   const indexPageTitle = config.INDEX_PAGE_TITLE || "Pastebin"
@@ -161,14 +163,14 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
         {isZipArchive ? (
           <>
             Not a renderable file (application/zip).{" "}
-            <a href={downloadUrl} download={pasteFile.name} className="text-primary-500 inline">
+            <a href={downloadUrl} download={pasteFile.name} className="text-primary inline">
               Download raw
             </a>
           </>
         ) : (
           <>
             This file seems to be binary or not in UTF-8{guessedEncoding ? ` (${guessedEncoding} guessed). ` : ". "}
-            <button className="text-primary-500 inline" onClick={() => setForceShowBinary(true)}>
+            <button className="text-primary inline" onClick={() => setForceShowBinary(true)}>
               (Click to show)
             </button>
           </>
@@ -178,8 +180,11 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   )
 
   const contentDisplayFilename = hasOriginalFiles ? `${originalFiles.length} files` : filename || metaFilename
-  const titleDisplayFilename = hasOriginalFiles ? `${originalFiles.length} files` : filenameForTitle(filename || metaFilename)
+  const titleDisplayFilename = hasOriginalFiles
+    ? `${originalFiles.length} files`
+    : filenameForTitle(filename || metaFilename)
   const placeholderName = contentDisplayFilename || (ext ? name + ext : name)
+  const rawDownloadUrl = pendingInfo || mediaInfo ? `${(pendingInfo ?? mediaInfo)!.rawUrl}?a` : "#"
   const placeholderReason = (() => {
     if (!pendingInfo) return ""
     const ct = pendingInfo.contentType
@@ -199,9 +204,15 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
       {hasOriginalFiles && <OriginalFileList files={originalFiles} />}
       <div className="w-fit text-center">
         {placeholderReason}{" "}
-        <Link href={`${pendingInfo.rawUrl}?a`} className="text-primary-500 inline">
-          Download raw
-        </Link>
+        {onDownloadPaste ? (
+          <button className="text-primary inline cursor-pointer" onClick={() => onDownloadPaste()}>
+            Download decrypted
+          </button>
+        ) : (
+          <Link href={`${pendingInfo.rawUrl}?a`} className="text-primary inline">
+            Download raw
+          </Link>
+        )}
         {onLoadAnyway && (
           <>
             {" or "}
@@ -217,7 +228,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
 
   const lineNumOffset = `${Math.floor(Math.log10(pasteLineCount)) + 3}ch`
   const buttonClasses = `${tst}`
-  const iconLinkClass = `inline-flex items-center justify-center rounded-full p-2 hover:bg-default-100 ${buttonClasses}`
+  const iconLinkClass = `inline-flex items-center justify-center rounded-full p-2 hover:bg-default-100 cursor-pointer ${buttonClasses}`
 
   return (
     <main
@@ -266,14 +277,20 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
             ) : (
               (pendingInfo || mediaInfo) && (
                 <Tooltip content={`Download as file`}>
-                  <a
-                    href={(pendingInfo ?? mediaInfo)!.rawUrl}
-                    download={placeholderName}
-                    aria-label="Download"
-                    className={iconLinkClass}
-                  >
-                    <DownloadIcon className="size-6 inline" />
-                  </a>
+                  {onDownloadPaste ? (
+                    <button
+                      type="button"
+                      onClick={() => onDownloadPaste()}
+                      aria-label="Download"
+                      className={iconLinkClass}
+                    >
+                      <DownloadIcon className="size-6 inline" />
+                    </button>
+                  ) : (
+                    <a href={rawDownloadUrl} download={placeholderName} aria-label="Download" className={iconLinkClass}>
+                      <DownloadIcon className="size-6 inline" />
+                    </a>
+                  )}
                 </Tooltip>
               )
             )}
@@ -313,7 +330,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
                         <span>{contentDisplayFilename || pasteFile?.name}</span>
                         <span>{`(${formatSize(pasteFile.size)})`}</span>
                         {forceShowBinary && (
-                          <button className="ml-2 text-primary-500" onClick={() => setForceShowBinary(false)}>
+                          <button className="ml-2 text-primary" onClick={() => setForceShowBinary(false)}>
                             (Click to hide)
                           </button>
                         )}

--- a/frontend/pages/DisplayPasteView.tsx
+++ b/frontend/pages/DisplayPasteView.tsx
@@ -3,6 +3,7 @@ import { CircularProgress, Link, Tooltip } from "../components/ui/index.js"
 import { DarkModeToggle, useDarkModeSelection } from "../components/DarkModeToggle.js"
 import { DownloadIcon, HomeIcon } from "../components/icons.js"
 import { CopyWidget } from "../components/CopyWidget.js"
+import { QrCodeTooltip } from "../components/QrCodeTooltip.js"
 import { tst } from "../utils/overrides.js"
 import { highlightHTML, useHljsForLang } from "../utils/highlight.js"
 import { formatSize } from "../utils/utils.js"
@@ -134,6 +135,13 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   const [, modeSelection, setModeSelection] = useDarkModeSelection()
   const hljs = useHljsForLang(pasteLang)
   const [downloadUrl, setDownloadUrl] = useState<string>("#")
+  const [displayUrl, setDisplayUrl] = useState<string>("")
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setDisplayUrl(window.location.href)
+    }
+  }, [])
 
   // Create and cleanup blob URL
   useEffect(() => {
@@ -228,7 +236,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
 
   const lineNumOffset = `${Math.floor(Math.log10(pasteLineCount)) + 3}ch`
   const buttonClasses = `${tst}`
-  const iconLinkClass = `inline-flex items-center justify-center rounded-full p-2 hover:bg-default-100 cursor-pointer ${buttonClasses}`
+  const iconLinkClass = `inline-flex items-center justify-center rounded-full p-1.5 text-default-600 hover:bg-default-100 cursor-pointer ${buttonClasses}`
 
   return (
     <main
@@ -240,7 +248,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
             <a
               href="/"
               aria-label={indexPageTitle}
-              className={`${iconLinkClass} text-foreground-500 md:hidden shrink-0`}
+              className={`${iconLinkClass} md:hidden shrink-0`}
             >
               <HomeIcon className="size-6" />
             </a>
@@ -263,10 +271,13 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
           </h1>
           <div className="flex flex-row gap-2 items-center">
             <DarkModeToggle modeSelection={modeSelection} setModeSelection={setModeSelection} />
-            {showFileContent && (
-              <Tooltip content={`Copy to clipboard`}>
-                <CopyWidget variant="light" className={buttonClasses} getCopyContent={() => pasteStringContent!} />
-              </Tooltip>
+            {displayUrl && (
+              <QrCodeTooltip
+                value={displayUrl}
+                placement="bottom"
+                className={`${buttonClasses}`}
+                tooltip="Show QR code"
+              />
             )}
             {pasteFile ? (
               <Tooltip content={`Download as file`}>
@@ -293,6 +304,11 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
                   )}
                 </Tooltip>
               )
+            )}
+            {showFileContent && (
+              <Tooltip content={`Copy to clipboard`}>
+                <CopyWidget variant="light" className={buttonClasses} getCopyContent={() => pasteStringContent!} />
+              </Tooltip>
             )}
           </div>
         </div>

--- a/frontend/pages/DisplayPasteView.tsx
+++ b/frontend/pages/DisplayPasteView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { Button, CircularProgress, Link, Tooltip } from "../components/ui/index.js"
+import { CircularProgress, Link, Tooltip } from "../components/ui/index.js"
 import { DarkModeToggle, useDarkModeSelection } from "../components/DarkModeToggle.js"
 import { DownloadIcon, HomeIcon } from "../components/icons.js"
 import { CopyWidget } from "../components/CopyWidget.js"
@@ -8,13 +8,13 @@ import { highlightHTML, useHljsForLang } from "../utils/highlight.js"
 import { formatSize } from "../utils/utils.js"
 
 interface PendingInfo {
-  sizeBytes: number
+  sizeBytes: number | null
   rawUrl: string
   contentType: string | null
 }
 
 interface MediaInfo {
-  sizeBytes: number
+  sizeBytes: number | null
   rawUrl: string
   contentType: string
 }
@@ -52,6 +52,10 @@ function MediaElement({ kind, src, name }: { kind: MediaKind; src: string; name:
     return <audio src={src} controls className="w-full" aria-label={name} />
   }
   return <video src={src} controls className="max-w-full h-auto mx-auto block" aria-label={name} />
+}
+
+function sizeSuffix(sizeBytes: number | null): string {
+  return sizeBytes === null ? "" : ` (${formatSize(sizeBytes)})`
 }
 
 interface DisplayPasteViewProps {
@@ -148,7 +152,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
   })()
   const pendingFileIndicator = pendingInfo && !pasteFile && (
     <div className="absolute top-[50%] left-[50%] translate-[-50%] flex flex-col items-center w-full px-4">
-      <div className="text-foreground-600 mb-2">{`${placeholderName} (${formatSize(pendingInfo.sizeBytes)})`}</div>
+      <div className="text-foreground-600 mb-2">{`${placeholderName}${sizeSuffix(pendingInfo.sizeBytes)}`}</div>
       <div className="w-fit text-center">
         {placeholderReason}{" "}
         <Link href={`${pendingInfo.rawUrl}?a`} className="text-primary-500 inline">
@@ -169,6 +173,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
 
   const lineNumOffset = `${Math.floor(Math.log10(pasteLineCount)) + 3}ch`
   const buttonClasses = `${tst}`
+  const iconLinkClass = `inline-flex items-center justify-center rounded-full p-2 hover:bg-default-100 ${buttonClasses}`
 
   return (
     <main
@@ -177,11 +182,15 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
       <div className="w-full max-w-[64rem]">
         <div className="flex flex-row my-4 items-center justify-between">
           <h1 className="text-xl md:text-2xl grow inline-flex items-baseline min-w-0">
-            <Link href="/" className="text-foreground-500 text-[length:inherited] shrink-0">
-              <Button isIconOnly variant="light" aria-label={indexPageTitle} className={buttonClasses + " md:hidden"}>
-                <HomeIcon className="size-6" />
-              </Button>
-              <span className="hidden md:inline">{indexPageTitle}</span>
+            <a
+              href="/"
+              aria-label={indexPageTitle}
+              className={`${iconLinkClass} text-foreground-500 md:hidden shrink-0`}
+            >
+              <HomeIcon className="size-6" />
+            </a>
+            <Link href="/" className="text-foreground-500 text-[length:inherited] shrink-0 hidden md:inline">
+              {indexPageTitle}
             </Link>
             <span className="mx-2 shrink-0">{" / "}</span>
             <span className="shrink-0">{displayFilename ? name : name + (ext ?? "")}</span>
@@ -206,20 +215,21 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
             )}
             {pasteFile ? (
               <Tooltip content={`Download as file`}>
-                <Button aria-label="Download" isIconOnly variant="light" className={buttonClasses}>
-                  <a href={downloadUrl} download={pasteFile.name}>
-                    <DownloadIcon className="size-6 inline" />
-                  </a>
-                </Button>
+                <a href={downloadUrl} download={pasteFile.name} aria-label="Download" className={iconLinkClass}>
+                  <DownloadIcon className="size-6 inline" />
+                </a>
               </Tooltip>
             ) : (
               (pendingInfo || mediaInfo) && (
                 <Tooltip content={`Download as file`}>
-                  <Button aria-label="Download" isIconOnly variant="light" className={buttonClasses}>
-                    <a href={(pendingInfo ?? mediaInfo)!.rawUrl} download={placeholderName}>
-                      <DownloadIcon className="size-6 inline" />
-                    </a>
-                  </Button>
+                  <a
+                    href={(pendingInfo ?? mediaInfo)!.rawUrl}
+                    download={placeholderName}
+                    aria-label="Download"
+                    className={iconLinkClass}
+                  >
+                    <DownloadIcon className="size-6 inline" />
+                  </a>
                 </Tooltip>
               )
             )}
@@ -235,7 +245,7 @@ export function DisplayPasteView(props: DisplayPasteViewProps) {
               <div>
                 <div className="text-gray-500 mb-2 text-sm flex flex-row gap-2">
                   <span>{placeholderName}</span>
-                  <span>{`(${formatSize(mediaInfo.sizeBytes)})`}</span>
+                  {mediaInfo.sizeBytes !== null && <span>{`(${formatSize(mediaInfo.sizeBytes)})`}</span>}
                 </div>
                 <MediaElement kind={mediaInfoKind} src={mediaInfo.rawUrl} name={placeholderName} />
               </div>

--- a/frontend/pages/PasteBin.tsx
+++ b/frontend/pages/PasteBin.tsx
@@ -27,7 +27,7 @@ export function PasteBin({ config }: { config: Env }) {
   const [editorState, setEditorState] = useState<PasteEditState>({
     editKind: "edit",
     editContent: "",
-    file: null,
+    files: [],
     editHighlightLang: "plaintext",
   })
 
@@ -110,7 +110,7 @@ export function PasteBin({ config }: { config: Env }) {
           setEditorState({
             editKind: "edit",
             editContent: await resp.text(),
-            file: null,
+            files: [],
             editHighlightLang: contentLang || undefined,
             editFilename: pasteFilename,
           })
@@ -173,7 +173,7 @@ export function PasteBin({ config }: { config: Env }) {
   function canUpload(): boolean {
     if (editorState.editKind === "edit" && editorState.editContent.length === 0) {
       return false
-    } else if (editorState.editKind === "file" && editorState.file === null) {
+    } else if (editorState.editKind === "file" && editorState.files.length === 0) {
       return false
     }
 

--- a/frontend/pages/PasteBin.tsx
+++ b/frontend/pages/PasteBin.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useTransition } from "react"
+import type { CSSProperties } from "react"
 
 import { Link } from "../components/ui/index.js"
 
@@ -9,8 +10,9 @@ import { PanelSettingsPanel } from "../components/PasteSettingPanel.js"
 import { UploadedPanel } from "../components/UploadedPanel.js"
 import type { PasteEditState } from "../components/PasteInputPanel.js"
 import { PasteInputPanel } from "../components/PasteInputPanel.js"
+import { LocalUploadsSidebar } from "../components/LocalUploadsSidebar.js"
 
-import type { PasteResponse } from "../../shared/interfaces.js"
+import type { MetaResponse, PasteResponse } from "../../shared/interfaces.js"
 import { parsePath, parseFilenameFromContentDisposition } from "../../shared/parsers.js"
 import { PASSWD_SEP, MAX_URL_REDIRECT_LEN, MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
 
@@ -19,9 +21,27 @@ import { verifyName, verifyPassword, isLegalUrl } from "../../shared/verify.js"
 import { useNameAvailability } from "../utils/useNameAvailability.js"
 import type { UploadProgress } from "../utils/uploader.js"
 import { uploadPaste } from "../utils/uploader.js"
+import type { LocalUploadRecord } from "../utils/localUploads.js"
+import { pasteKeyFromUrl } from "../utils/pasteUrls.js"
+import { useLocalUploads } from "../utils/useLocalUploads.js"
 import { tst } from "../utils/overrides.js"
+import type { EncryptionScheme } from "../utils/encryption.js"
+import { decodeKey, decrypt } from "../utils/encryption.js"
 
 import "../style.css"
+
+function isMetaResponse(value: unknown): value is MetaResponse {
+  return typeof value === "object" && value !== null && typeof (value as MetaResponse).sizeBytes === "number"
+}
+
+function parseContentLength(value: string | null): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : Number.NaN
+}
+
+function stripEncryptedSuffix(filename: string | undefined): string | undefined {
+  return filename?.replace(/\.encrypted$/, "")
+}
 
 export function PasteBin({ config }: { config: Env }) {
   const [editorState, setEditorState] = useState<PasteEditState>({
@@ -47,7 +67,11 @@ export function PasteBin({ config }: { config: Env }) {
   const [isDeletePending, startDelete] = useTransition()
   const [loadingProgress, setLoadingProgress] = useState<UploadProgress | undefined>(undefined)
   const uploadAbortRef = useRef<AbortController | null>(null)
+  const mainUploadAreaRef = useRef<HTMLDivElement | null>(null)
   const [isInitPasteLoading, startFetchingInitPaste] = useTransition()
+  const { localUploads, rememberLocalUpload, removeLocalUploadByKey } = useLocalUploads()
+  const [latestLocalUploadKey, setLatestLocalUploadKey] = useState<string | undefined>(undefined)
+  const [mainUploadAreaHeight, setMainUploadAreaHeight] = useState<number | undefined>(undefined)
 
   const [_, modeSelection, setModeSelection] = useDarkModeSelection()
 
@@ -59,6 +83,20 @@ export function PasteBin({ config }: { config: Env }) {
     pasteSetting.uploadKind === "custom",
   )
 
+  useEffect(() => {
+    const element = mainUploadAreaRef.current
+    if (!element || typeof ResizeObserver === "undefined") return
+
+    const updateHeight = () => {
+      setMainUploadAreaHeight(Math.ceil(element.getBoundingClientRect().height))
+    }
+
+    updateHeight()
+    const observer = new ResizeObserver(updateHeight)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
   // handle admin URL
   useEffect(() => {
     // SSR environment check
@@ -69,30 +107,58 @@ export function PasteBin({ config }: { config: Env }) {
     const { name, password, filename, ext } = parsePath(pathname)
 
     if (password !== undefined && pasteSetting.manageUrl === "") {
-      setPasteSetting({
-        ...pasteSetting,
+      setPasteSetting((prev) => ({
+        ...prev,
         uploadKind: "manage",
         manageUrl: `${config.DEPLOY_URL}/${name}:${password}`,
-      })
+      }))
 
       let pasteUrl = `${config.DEPLOY_URL}/${name}`
       if (filename) pasteUrl = `${pasteUrl}/${filename}`
       if (ext) pasteUrl = `${pasteUrl}${ext}`
+      const metadataUrl = `${config.DEPLOY_URL}/m/${name}`
 
       startFetchingInitPaste(async () => {
         try {
+          const metaResp = await fetch(metadataUrl)
+          if (!metaResp.ok) {
+            await handleFailedResp(`Error on Fetching ${metadataUrl}`, metaResp)
+            return
+          }
+          const metadata: unknown = await metaResp.json()
+          if (!isMetaResponse(metadata)) {
+            showModal("Error on Fetching Paste Metadata", "The metadata response is invalid.")
+            return
+          }
+          const encryptionScheme = metadata.encryptionScheme as EncryptionScheme | undefined
+          const isEncrypted = encryptionScheme !== undefined
+          if (isEncrypted) {
+            setPasteSetting((prev) => ({ ...prev, doEncrypt: true }))
+          }
+
           const headResp = await fetch(pasteUrl, { method: "HEAD" })
           if (!headResp.ok) {
             await handleFailedResp(`Error on Fetching ${pasteUrl}`, headResp)
             return
           }
           const contentType = headResp.headers.get("Content-Type")
-          const contentLength = Number(headResp.headers.get("Content-Length"))
-          const contentLang = headResp.headers.get("X-PB-Highlight-Language")
+          const decryptedContentType = headResp.headers.get("X-PB-Decrypted-Content-Type")
+          const effectiveContentType = isEncrypted ? decryptedContentType : contentType
+          const contentLength = parseContentLength(headResp.headers.get("Content-Length"))
+          const contentLang = headResp.headers.get("X-PB-Highlight-Language") || metadata.highlightLanguage
           const contentDisp = headResp.headers.get("Content-Disposition")
 
-          const isText = contentType?.startsWith("text/") || !!contentLang
+          const isText = effectiveContentType?.startsWith("text/") || !!contentLang
           if (!isText || !Number.isFinite(contentLength) || contentLength >= MAX_AUTO_FETCH_BYTES) {
+            return
+          }
+
+          const keyString = location.hash.slice(1)
+          if (isEncrypted && keyString.length === 0) {
+            showModal(
+              "Decryption key required",
+              "This paste is encrypted. Open the manage URL with the decryption key after # to edit the plaintext.",
+            )
             return
           }
 
@@ -106,10 +172,36 @@ export function PasteBin({ config }: { config: Env }) {
           if (pasteFilename === undefined && contentDisp !== null) {
             pasteFilename = parseFilenameFromContentDisposition(contentDisp)
           }
+          if (isEncrypted) pasteFilename = stripEncryptedSuffix(pasteFilename)
+          pasteFilename ||= metadata.filename
+
+          let editContent: string
+          if (isEncrypted) {
+            let key: CryptoKey
+            try {
+              key = await decodeKey(encryptionScheme, keyString)
+            } catch (err) {
+              showModal("Invalid decryption key", (err as Error).message)
+              return
+            }
+            const encryptedBytes = new Uint8Array(await resp.arrayBuffer())
+            const decrypted = await decrypt(encryptionScheme, key, encryptedBytes)
+            if (!decrypted) {
+              showModal(
+                "Decryption failed",
+                "Could not decrypt the paste with the provided key. The URL fragment may be wrong, " +
+                  "or the paste has been replaced or corrupted.",
+              )
+              return
+            }
+            editContent = new TextDecoder().decode(decrypted)
+          } else {
+            editContent = await resp.text()
+          }
 
           setEditorState({
             editKind: "edit",
-            editContent: await resp.text(),
+            editContent,
             files: [],
             editHighlightLang: contentLang || undefined,
             editFilename: pasteFilename,
@@ -129,15 +221,21 @@ export function PasteBin({ config }: { config: Env }) {
     setUploadedEncryptionKey(undefined)
     startUpload(async () => {
       try {
+        let nextEncryptionKey: string | undefined
         const uploaded = await uploadPaste(
           pasteSetting,
           editorState,
-          setUploadedEncryptionKey,
+          (key) => {
+            nextEncryptionKey = key
+            setUploadedEncryptionKey(key)
+          },
           config,
           setLoadingProgress,
           controller.signal,
         )
         setPasteResponse(uploaded)
+        rememberLocalUpload(uploaded, nextEncryptionKey)
+        setLatestLocalUploadKey(pasteKeyFromUrl(uploaded.url))
         setPasteSetting({ ...pasteSetting, uploadKind: "manage", manageUrl: uploaded.manageUrl })
       } catch (e) {
         if ((e as Error).name !== "AbortError") {
@@ -159,6 +257,7 @@ export function PasteBin({ config }: { config: Env }) {
         const resp = await fetch(pasteSetting.manageUrl, { method: "DELETE" })
         if (resp.ok) {
           showModal("Deleted Successfully", "It may takes 60 seconds for the deletion to propagate to the world")
+          removeLocalUploadByKey(pasteKeyFromUrl(pasteSetting.manageUrl))
           setPasteResponse(undefined)
           setPasteSetting({ ...pasteSetting, uploadKind: "short", manageUrl: "" })
         } else {
@@ -200,6 +299,29 @@ export function PasteBin({ config }: { config: Env }) {
 
   function canDelete(): boolean {
     return verifyManageUrl(pasteSetting.manageUrl, config)[0]
+  }
+
+  function removeLocalUploadFromState(upload: LocalUploadRecord) {
+    removeLocalUploadByKey(upload.key)
+    if (verifyManageUrl(pasteSetting.manageUrl, config)[0] && pasteKeyFromUrl(pasteSetting.manageUrl) === upload.key) {
+      setPasteResponse(undefined)
+      setPasteSetting({ ...pasteSetting, uploadKind: "short", manageUrl: "" })
+    }
+  }
+
+  async function onDeleteLocalUpload(upload: LocalUploadRecord) {
+    try {
+      const resp = await fetch(upload.manageUrl, { method: "DELETE" })
+      if (resp.ok) {
+        removeLocalUploadFromState(upload)
+      } else if (resp.status === 404 || resp.status === 410) {
+        removeLocalUploadFromState(upload)
+      } else {
+        await handleFailedResp("Error on Delete Paste", resp)
+      }
+    } catch (e) {
+      handleError("Error on Delete Paste", e as Error)
+    }
   }
 
   const info = (
@@ -272,42 +394,56 @@ export function PasteBin({ config }: { config: Env }) {
 
   return (
     <main className={`flex flex-col items-center min-h-screen font-sans ${tst} bg-background text-foreground`}>
-      <div className="grow w-full max-w-[64rem]">
+      <div className="grow w-full max-w-[88rem] px-2 lg:px-4 xl:px-0">
         {info}
-        <PasteInputPanel
-          isPasteLoading={isInitPasteLoading}
-          state={editorState}
-          onStateChange={setEditorState}
-          config={config}
-          showModal={showModal}
-          className="mt-6 mb-4 mx-2 lg:mx-0"
-        />
-        <div className="flex flex-col items-start lg:flex-row gap-4 mx-2 lg:mx-0">
-          <PanelSettingsPanel
-            config={config}
-            className={"transition-width lg:w-1/2 w-full"}
-            setting={pasteSetting}
-            onSettingChange={setPasteSetting}
-            nameAvailability={nameAvailability}
-            footer={submitter}
-          />
-          {(pasteResponse || isUploadPending) && (
-            <UploadedPanel
-              isLoading={isUploadPending}
-              loadingProgress={loadingProgress}
-              onCancel={onCancelUpload}
-              pasteResponse={pasteResponse}
-              encryptionKey={uploadedEncryptionKey}
-              highlightLang={editorState.editKind === "edit" ? editorState.editHighlightLang : undefined}
-              isUrlPaste={
-                editorState.editKind === "edit" &&
-                editorState.editContent.length > 0 &&
-                editorState.editContent.length <= MAX_URL_REDIRECT_LEN &&
-                isLegalUrl(editorState.editContent)
-              }
-              className="w-full lg:w-1/2"
+        <div className="flex w-full flex-col gap-6 xl:flex-row xl:items-start">
+          <div ref={mainUploadAreaRef} className="min-w-0 flex-1">
+            <PasteInputPanel
+              isPasteLoading={isInitPasteLoading}
+              state={editorState}
+              onStateChange={setEditorState}
+              config={config}
+              showModal={showModal}
+              className="mt-6 mb-4 mx-0"
             />
-          )}
+            <div className="flex flex-col items-start lg:flex-row gap-4 mx-0">
+              <PanelSettingsPanel
+                config={config}
+                className={"transition-width lg:w-1/2 w-full"}
+                setting={pasteSetting}
+                onSettingChange={setPasteSetting}
+                nameAvailability={nameAvailability}
+                footer={submitter}
+              />
+              {(pasteResponse || isUploadPending) && (
+                <UploadedPanel
+                  isLoading={isUploadPending}
+                  loadingProgress={loadingProgress}
+                  onCancel={onCancelUpload}
+                  pasteResponse={pasteResponse}
+                  encryptionKey={uploadedEncryptionKey}
+                  highlightLang={editorState.editKind === "edit" ? editorState.editHighlightLang : undefined}
+                  isUrlPaste={
+                    editorState.editKind === "edit" &&
+                    editorState.editContent.length > 0 &&
+                    editorState.editContent.length <= MAX_URL_REDIRECT_LEN &&
+                    isLegalUrl(editorState.editContent)
+                  }
+                  className="w-full lg:w-1/2"
+                />
+              )}
+            </div>
+          </div>
+          <LocalUploadsSidebar
+            uploads={localUploads}
+            onDeleteUpload={onDeleteLocalUpload}
+            scrollToKey={latestLocalUploadKey}
+            style={
+              mainUploadAreaHeight === undefined
+                ? undefined
+                : ({ "--local-uploads-height": `${mainUploadAreaHeight}px` } as CSSProperties)
+            }
+          />
         </div>
       </div>
       {footer}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -17,6 +17,7 @@
   --color-default-300: #d4d4d8;
   --color-default-400: #a1a1aa;
   --color-default-500: #71717a;
+  --color-default-600: #52525b;
   --color-default-700: #3f3f46;
   --color-divider: #e4e4e7;
   --color-primary: #006fee;
@@ -42,6 +43,7 @@
   --color-default-300: #52525b;
   --color-default-400: #71717a;
   --color-default-500: #a1a1aa;
+  --color-default-600: #b8b8c0;
   --color-default-700: #d4d4d8;
   --color-divider: #3f3f46;
   --color-primary: #bef264;

--- a/frontend/test/display.spec.tsx
+++ b/frontend/test/display.spec.tsx
@@ -8,7 +8,7 @@ import { setupServer } from "msw/node"
 import { http, HttpResponse } from "msw"
 import { encodeKey, encrypt, genKey } from "../utils/encryption.js"
 import { stubBrowerFunctions, unStubBrowerFunctions } from "./testUtils.js"
-import { MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
+import { DEFAULT_EDIT_FILENAME, MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
 import type { SerializedPasteData } from "../../shared/interfaces.js"
 import { formatSize } from "../utils/utils.js"
 
@@ -287,6 +287,64 @@ describe("DisplayPaste", () => {
     expect(article.textContent).toStrictEqual(text)
     const heading = await screen.findByRole("heading")
     expect(heading.textContent).toContain("ssr.txt")
+  })
+
+  it("hides the default Untitled filename from the heading but keeps it for content and download", async () => {
+    const text = "untitled hello"
+    const injected: SerializedPasteData = {
+      content: btoa(text),
+      name: "abcd",
+      isBinary: false,
+      guessedEncoding: "UTF-8",
+      metadata: {
+        lastModifiedAt: "",
+        createdAt: "",
+        expireAt: "",
+        sizeBytes: text.length,
+        location: "KV",
+        filename: DEFAULT_EDIT_FILENAME,
+      },
+    }
+    window.__PASTE_DATA__ = injected
+    vi.stubGlobal("location", new URL("https://example.com/d/abcd"))
+
+    render(<DisplayPaste config={__WRANGLER_CONFIG__} />)
+
+    const article = await screen.findByRole("article")
+    expect(article.textContent).toStrictEqual(text)
+
+    const heading = await screen.findByRole("heading")
+    expect(heading.textContent).not.toContain(DEFAULT_EDIT_FILENAME)
+    expect(screen.getByText(DEFAULT_EDIT_FILENAME)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Download" }).getAttribute("download")).toStrictEqual(
+      DEFAULT_EDIT_FILENAME,
+    )
+  })
+
+  it("shows SSR-injected zip content as a non-renderable archive", async () => {
+    const zipBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00])
+    const injected: SerializedPasteData = {
+      content: btoa(String.fromCharCode(...zipBytes)),
+      name: "abcd",
+      isBinary: true,
+      guessedEncoding: null,
+      metadata: {
+        lastModifiedAt: "",
+        createdAt: "",
+        expireAt: "",
+        sizeBytes: zipBytes.byteLength,
+        location: "KV",
+        filename: "files.zip",
+      },
+    }
+    window.__PASTE_DATA__ = injected
+    vi.stubGlobal("location", new URL("https://example.com/d/abcd"))
+
+    render(<DisplayPaste config={__WRANGLER_CONFIG__} />)
+
+    expect(await screen.findByText(/Not a renderable file \(application\/zip\)/)).toBeInTheDocument()
+    expect(screen.getByText("Download raw")).toBeInTheDocument()
+    expect(screen.queryByText(/not in UTF-8/)).not.toBeInTheDocument()
   })
 
   it("fetches and renders content when user clicks load anyway on oversized text", async () => {

--- a/frontend/test/display.spec.tsx
+++ b/frontend/test/display.spec.tsx
@@ -316,9 +316,7 @@ describe("DisplayPaste", () => {
     const heading = await screen.findByRole("heading")
     expect(heading.textContent).not.toContain(DEFAULT_EDIT_FILENAME)
     expect(screen.getByText(DEFAULT_EDIT_FILENAME)).toBeInTheDocument()
-    expect(screen.getByRole("link", { name: "Download" }).getAttribute("download")).toStrictEqual(
-      DEFAULT_EDIT_FILENAME,
-    )
+    expect(screen.getByRole("link", { name: "Download" }).getAttribute("download")).toStrictEqual(DEFAULT_EDIT_FILENAME)
   })
 
   it("shows SSR-injected zip content as a non-renderable archive", async () => {
@@ -437,5 +435,141 @@ describe("DisplayPaste", () => {
 
     expect(await screen.findByText(/Not a renderable file/)).toBeInTheDocument()
     expect(screen.getByText("Download raw")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Download" }).getAttribute("href")).toStrictEqual("/abcd?a")
+  })
+
+  it("downloads pending plain media through attachment URL without paste data", async () => {
+    let getCalled = false
+    server.use(
+      http.head("/abcd", () => {
+        return new HttpResponse(null, {
+          headers: {
+            "Content-Type": "video/mp4",
+            "Content-Length": "9999999",
+            "Content-Disposition": "inline; filename*=UTF-8''clip.mp4",
+          },
+        })
+      }),
+      http.get("/abcd", () => {
+        getCalled = true
+        return new HttpResponse(null, { status: 500 })
+      }),
+    )
+    vi.stubGlobal("location", new URL("https://example.com/d/abcd"))
+
+    render(<DisplayPaste config={__WRANGLER_CONFIG__} />)
+
+    await screen.findByLabelText("clip.mp4")
+    const downloadLink = screen.getByRole("link", { name: "Download" })
+    expect(downloadLink.getAttribute("href")).toStrictEqual("/abcd?a")
+    expect(downloadLink.getAttribute("download")).toStrictEqual("clip.mp4")
+    expect(getCalled).toStrictEqual(false)
+  })
+
+  it("decrypts pending encrypted zip before download", async () => {
+    const scheme = "AES-GCM"
+    const key = await genKey(scheme)
+    const zipBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00])
+    const encryptedBytes = await encrypt(scheme, key, zipBytes)
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined)
+    const createObjectUrlSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock")
+    server.use(
+      ...mockPaste("abcd", {
+        body: encryptedBytes.buffer as ArrayBuffer,
+        headers: {
+          "X-PB-Encryption-Scheme": "AES-GCM",
+          "X-PB-Decrypted-Content-Type": "application/zip",
+          "Content-Type": "application/octet-stream",
+          "Content-Disposition": "inline; filename*=UTF-8''files.zip.encrypted",
+        },
+      }),
+      http.get("/m/abcd", () => {
+        return HttpResponse.json({
+          lastModifiedAt: "",
+          createdAt: "",
+          expireAt: "",
+          sizeBytes: encryptedBytes.byteLength,
+          location: "KV",
+          filename: "files.zip",
+        })
+      }),
+    )
+    vi.stubGlobal("location", new URL(`https://example.com/d/abcd#${await encodeKey(key)}`))
+
+    render(<DisplayPaste config={__WRANGLER_CONFIG__} />)
+
+    try {
+      const downloadButton = await screen.findByRole("button", { name: "Download" })
+      await userEvent.click(downloadButton)
+
+      await waitFor(() => {
+        expect(createObjectUrlSpy).toHaveBeenCalled()
+      })
+      expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument()
+      expect(screen.getByText("Download decrypted")).toBeInTheDocument()
+      expect(screen.queryByRole("link", { name: "Download" })).not.toBeInTheDocument()
+    } finally {
+      clickSpy.mockRestore()
+      createObjectUrlSpy.mockRestore()
+    }
+  })
+
+  it("uses metadata filename for decrypted pending downloads when raw response has no filename", async () => {
+    const scheme = "AES-GCM"
+    const key = await genKey(scheme)
+    const encryptedBytes = await encrypt(scheme, key, new TextEncoder().encode("secret text"))
+    let downloadAnchor: HTMLAnchorElement | undefined
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined)
+    server.use(
+      http.head("/abcd", () => {
+        return new HttpResponse(null, {
+          headers: {
+            "X-PB-Encryption-Scheme": "AES-GCM",
+            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": String(MAX_AUTO_FETCH_BYTES + 1),
+          },
+        })
+      }),
+      http.get("/abcd", () => {
+        return HttpResponse.arrayBuffer(encryptedBytes.buffer as ArrayBuffer, {
+          headers: {
+            "X-PB-Encryption-Scheme": "AES-GCM",
+            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": String(encryptedBytes.byteLength),
+          },
+        })
+      }),
+      http.get("/m/abcd", () => {
+        return HttpResponse.json({
+          lastModifiedAt: "",
+          createdAt: "",
+          expireAt: "",
+          sizeBytes: encryptedBytes.byteLength,
+          location: "KV",
+          filename: "original-name",
+        })
+      }),
+    )
+    vi.stubGlobal("location", new URL(`https://example.com/d/abcd#${await encodeKey(key)}`))
+
+    render(<DisplayPaste config={__WRANGLER_CONFIG__} />)
+
+    const appendSpy = vi.spyOn(document.body, "appendChild").mockImplementation((node: Node) => {
+      downloadAnchor = node as HTMLAnchorElement
+      return node
+    })
+
+    try {
+      await userEvent.click(await screen.findByRole("button", { name: "Download" }))
+
+      await waitFor(() => {
+        expect(downloadAnchor?.download).toStrictEqual("original-name")
+      })
+    } finally {
+      clickSpy.mockRestore()
+      appendSpy.mockRestore()
+    }
   })
 })

--- a/frontend/test/display.spec.tsx
+++ b/frontend/test/display.spec.tsx
@@ -8,7 +8,7 @@ import { setupServer } from "msw/node"
 import { http, HttpResponse } from "msw"
 import { encodeKey, encrypt, genKey } from "../utils/encryption.js"
 import { stubBrowerFunctions, unStubBrowerFunctions } from "./testUtils.js"
-import { DEFAULT_EDIT_FILENAME, MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
+import { BINARY_MIME_TYPE, DEFAULT_EDIT_FILENAME, MAX_AUTO_FETCH_BYTES, TEXT_MIME_TYPE } from "../../shared/constants.js"
 import type { SerializedPasteData } from "../../shared/interfaces.js"
 import { formatSize } from "../utils/utils.js"
 
@@ -50,7 +50,7 @@ describe("DisplayPaste", () => {
     server.use(
       ...mockPaste("abcd", {
         body: new TextEncoder().encode(text).buffer,
-        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        headers: { "Content-Type": TEXT_MIME_TYPE },
       }),
     )
     vi.stubGlobal("location", new URL("https://example.com/d/abcd"))
@@ -152,7 +152,7 @@ describe("DisplayPaste", () => {
         headers: {
           "X-PB-Encryption-Scheme": "AES-GCM",
           "X-PB-Decrypted-Content-Type": "audio/mpeg",
-          "Content-Type": "application/octet-stream",
+          "Content-Type": BINARY_MIME_TYPE,
           "Content-Disposition": "inline; filename*=UTF-8''song.mp3.encrypted",
         },
       }),
@@ -177,7 +177,7 @@ describe("DisplayPaste", () => {
         headers: {
           "X-PB-Encryption-Scheme": "AES-GCM",
           "X-PB-Decrypted-Content-Type": "image/png",
-          "Content-Type": "application/octet-stream",
+          "Content-Type": BINARY_MIME_TYPE,
           "Content-Disposition": "inline; filename*=UTF-8''photo.png.encrypted",
         },
       }),
@@ -201,8 +201,8 @@ describe("DisplayPaste", () => {
         body: encryptedBytes.buffer as ArrayBuffer,
         headers: {
           "X-PB-Encryption-Scheme": "AES-GCM",
-          "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
-          "Content-Type": "application/octet-stream",
+          "X-PB-Decrypted-Content-Type": TEXT_MIME_TYPE,
+          "Content-Type": BINARY_MIME_TYPE,
         },
       }),
     )
@@ -221,7 +221,7 @@ describe("DisplayPaste", () => {
       http.head("/abcd", () => {
         return new HttpResponse(null, {
           headers: {
-            "Content-Type": "text/plain;charset=UTF-8",
+            "Content-Type": TEXT_MIME_TYPE,
             "Content-Length": String(oversized.byteLength),
           },
         })
@@ -350,7 +350,7 @@ describe("DisplayPaste", () => {
     server.use(
       ...mockPaste("abcd", {
         body: oversized.buffer,
-        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        headers: { "Content-Type": TEXT_MIME_TYPE },
       }),
     )
     vi.stubGlobal("location", new URL("https://example.com/d/abcd"))
@@ -375,7 +375,7 @@ describe("DisplayPaste", () => {
         headers: {
           "X-PB-Encryption-Scheme": "AES-GCM",
           "X-PB-Decrypted-Content-Type": "video/mp4",
-          "Content-Type": "application/octet-stream",
+          "Content-Type": BINARY_MIME_TYPE,
           "Content-Disposition": "inline; filename*=UTF-8''clip.mp4.encrypted",
         },
       }),
@@ -396,7 +396,7 @@ describe("DisplayPaste", () => {
       http.head("/abcd", () => {
         // No Content-Length header at all (e.g. chunked response).
         return new HttpResponse(null, {
-          headers: { "Content-Type": "text/plain;charset=UTF-8" },
+          headers: { "Content-Type": TEXT_MIME_TYPE },
         })
       }),
       http.get("/m/abcd", () => {
@@ -479,7 +479,7 @@ describe("DisplayPaste", () => {
         headers: {
           "X-PB-Encryption-Scheme": "AES-GCM",
           "X-PB-Decrypted-Content-Type": "application/zip",
-          "Content-Type": "application/octet-stream",
+          "Content-Type": BINARY_MIME_TYPE,
           "Content-Disposition": "inline; filename*=UTF-8''files.zip.encrypted",
         },
       }),
@@ -525,8 +525,8 @@ describe("DisplayPaste", () => {
         return new HttpResponse(null, {
           headers: {
             "X-PB-Encryption-Scheme": "AES-GCM",
-            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
-            "Content-Type": "application/octet-stream",
+            "X-PB-Decrypted-Content-Type": TEXT_MIME_TYPE,
+            "Content-Type": BINARY_MIME_TYPE,
             "Content-Length": String(MAX_AUTO_FETCH_BYTES + 1),
           },
         })
@@ -535,8 +535,8 @@ describe("DisplayPaste", () => {
         return HttpResponse.arrayBuffer(encryptedBytes.buffer as ArrayBuffer, {
           headers: {
             "X-PB-Encryption-Scheme": "AES-GCM",
-            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
-            "Content-Type": "application/octet-stream",
+            "X-PB-Decrypted-Content-Type": TEXT_MIME_TYPE,
+            "Content-Type": BINARY_MIME_TYPE,
             "Content-Length": String(encryptedBytes.byteLength),
           },
         })

--- a/frontend/test/display.spec.tsx
+++ b/frontend/test/display.spec.tsx
@@ -10,6 +10,7 @@ import { encodeKey, encrypt, genKey } from "../utils/encryption.js"
 import { stubBrowerFunctions, unStubBrowerFunctions } from "./testUtils.js"
 import { MAX_AUTO_FETCH_BYTES } from "../../shared/constants.js"
 import type { SerializedPasteData } from "../../shared/interfaces.js"
+import { formatSize } from "../utils/utils.js"
 
 interface RespInit {
   body: ArrayBuffer
@@ -334,11 +335,21 @@ describe("DisplayPaste", () => {
 
   it("falls back to placeholder when Content-Length is missing on text", async () => {
     let getCalled = false
+    const sizeBytes = MAX_AUTO_FETCH_BYTES + 1
     server.use(
       http.head("/abcd", () => {
         // No Content-Length header at all (e.g. chunked response).
         return new HttpResponse(null, {
           headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        })
+      }),
+      http.get("/m/abcd", () => {
+        return HttpResponse.json({
+          lastModifiedAt: "",
+          createdAt: "",
+          expireAt: "",
+          sizeBytes,
+          location: "R2",
         })
       }),
       http.get("/abcd", () => {
@@ -351,6 +362,7 @@ describe("DisplayPaste", () => {
     render(<DisplayPaste config={__WRANGLER_CONFIG__} />)
 
     expect(await screen.findByText("load anyway")).toBeInTheDocument()
+    expect(screen.getByText(`abcd (${formatSize(sizeBytes)})`)).toBeInTheDocument()
     expect(getCalled).toStrictEqual(false)
   })
 

--- a/frontend/test/index.spec.tsx
+++ b/frontend/test/index.spec.tsx
@@ -29,7 +29,7 @@ export const server = setupServer(
   http.head(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
     return new HttpResponse(null, {
       headers: {
-        "Content-Type": "text/plain;charset=UTF-8",
+        "Content-Type": TEXT_MIME_TYPE,
         "Content-Length": String(new TextEncoder().encode(mockedPasteContent).length),
       },
     })
@@ -60,6 +60,7 @@ afterAll(() => {
 import "@testing-library/jest-dom/vitest"
 import { userEvent } from "@testing-library/user-event"
 import type { PasteResponse } from "../../shared/interfaces.js"
+import { BINARY_MIME_TYPE, TEXT_MIME_TYPE } from "../../shared/constants.js"
 import { setupServer } from "msw/node"
 import { http, HttpResponse } from "msw"
 import { stubBrowerFunctions, unStubBrowerFunctions } from "./testUtils.js"
@@ -129,10 +130,10 @@ describe("Pastebin admin page", () => {
       http.head(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
         return new HttpResponse(null, {
           headers: {
-            "Content-Type": "application/octet-stream",
+            "Content-Type": BINARY_MIME_TYPE,
             "Content-Length": String(ciphertext.length),
             "X-PB-Encryption-Scheme": "AES-GCM",
-            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+            "X-PB-Decrypted-Content-Type": TEXT_MIME_TYPE,
             "X-PB-Highlight-Language": "plaintext",
           },
         })
@@ -140,9 +141,9 @@ describe("Pastebin admin page", () => {
       http.get(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
         return new HttpResponse(ciphertext, {
           headers: {
-            "Content-Type": "application/octet-stream",
+            "Content-Type": BINARY_MIME_TYPE,
             "X-PB-Encryption-Scheme": "AES-GCM",
-            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+            "X-PB-Decrypted-Content-Type": TEXT_MIME_TYPE,
           },
         })
       }),
@@ -171,10 +172,10 @@ describe("Pastebin admin page", () => {
       http.head(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
         return new HttpResponse(null, {
           headers: {
-            "Content-Type": "application/octet-stream",
+            "Content-Type": BINARY_MIME_TYPE,
             "Content-Length": String(ciphertext.length),
             "X-PB-Encryption-Scheme": "AES-GCM",
-            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+            "X-PB-Decrypted-Content-Type": TEXT_MIME_TYPE,
             "X-PB-Highlight-Language": "plaintext",
           },
         })

--- a/frontend/test/index.spec.tsx
+++ b/frontend/test/index.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, vi, expect, beforeAll, afterEach, afterAll } from "vitest"
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import { PasteBin } from "../pages/PasteBin.js"
 
 export const mockedPasteUpload: PasteResponse = {
@@ -14,6 +14,13 @@ export const mockedPasteUpload: PasteResponse = {
 }
 
 export const mockedPasteContent = "something"
+export const mockedPasteMeta = {
+  lastModifiedAt: mockedPasteUpload.lastModifiedAt,
+  createdAt: mockedPasteUpload.createdAt,
+  expireAt: mockedPasteUpload.expireAt,
+  sizeBytes: mockedPasteUpload.sizeBytes,
+  location: mockedPasteUpload.location,
+}
 
 export const server = setupServer(
   http.post(`${__WRANGLER_CONFIG__.DEPLOY_URL}/`, () => {
@@ -29,6 +36,9 @@ export const server = setupServer(
   }),
   http.get(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
     return HttpResponse.text(mockedPasteContent)
+  }),
+  http.get(`${__WRANGLER_CONFIG__.DEPLOY_URL}/m/abcd`, () => {
+    return HttpResponse.json(mockedPasteMeta)
   }),
 )
 
@@ -53,6 +63,7 @@ import type { PasteResponse } from "../../shared/interfaces.js"
 import { setupServer } from "msw/node"
 import { http, HttpResponse } from "msw"
 import { stubBrowerFunctions, unStubBrowerFunctions } from "./testUtils.js"
+import { encodeKey, encrypt, genKey } from "../utils/encryption.js"
 
 describe("Pastebin", () => {
   it("can upload", async () => {
@@ -97,8 +108,84 @@ describe("Pastebin admin page", () => {
     render(<PasteBin config={__WRANGLER_CONFIG__} />)
 
     const editor = screen.getByRole("textbox", { name: "Paste editor" })
-    await userEvent.click(editor) // meaningless click, just ensure useEffect is done
     expect(editor).toBeInTheDocument()
-    expect((editor as HTMLTextAreaElement).value).toStrictEqual(mockedPasteContent)
+    await waitFor(() => expect((editor as HTMLTextAreaElement).value).toStrictEqual(mockedPasteContent))
+  })
+
+  it("decrypts encrypted admin text when the URL hash has the key", async () => {
+    const key = await genKey("AES-GCM")
+    const encodedKey = await encodeKey(key)
+    const ciphertext = await encrypt("AES-GCM", key, new TextEncoder().encode(mockedPasteContent))
+    vi.stubGlobal("location", new URL(`https://example.com/abcd:xxxxxxxxx#${encodedKey}`))
+    server.use(
+      http.get(`${__WRANGLER_CONFIG__.DEPLOY_URL}/m/abcd`, () => {
+        return HttpResponse.json({
+          ...mockedPasteMeta,
+          sizeBytes: ciphertext.length,
+          highlightLanguage: "plaintext",
+          encryptionScheme: "AES-GCM",
+        })
+      }),
+      http.head(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
+        return new HttpResponse(null, {
+          headers: {
+            "Content-Type": "application/octet-stream",
+            "Content-Length": String(ciphertext.length),
+            "X-PB-Encryption-Scheme": "AES-GCM",
+            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+            "X-PB-Highlight-Language": "plaintext",
+          },
+        })
+      }),
+      http.get(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
+        return new HttpResponse(ciphertext, {
+          headers: {
+            "Content-Type": "application/octet-stream",
+            "X-PB-Encryption-Scheme": "AES-GCM",
+            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+          },
+        })
+      }),
+    )
+
+    render(<PasteBin config={__WRANGLER_CONFIG__} />)
+
+    const editor = screen.getByRole("textbox", { name: "Paste editor" })
+    await waitFor(() => expect((editor as HTMLTextAreaElement).value).toStrictEqual(mockedPasteContent))
+    expect(screen.getByRole("checkbox", { name: "Client-side encryption" })).toBeChecked()
+  })
+
+  it("does not render encrypted admin text without the URL hash key", async () => {
+    const key = await genKey("AES-GCM")
+    const ciphertext = await encrypt("AES-GCM", key, new TextEncoder().encode(mockedPasteContent))
+    vi.stubGlobal("location", new URL("https://example.com/abcd:xxxxxxxxx"))
+    server.use(
+      http.get(`${__WRANGLER_CONFIG__.DEPLOY_URL}/m/abcd`, () => {
+        return HttpResponse.json({
+          ...mockedPasteMeta,
+          sizeBytes: ciphertext.length,
+          highlightLanguage: "plaintext",
+          encryptionScheme: "AES-GCM",
+        })
+      }),
+      http.head(`${__WRANGLER_CONFIG__.DEPLOY_URL}/abcd`, () => {
+        return new HttpResponse(null, {
+          headers: {
+            "Content-Type": "application/octet-stream",
+            "Content-Length": String(ciphertext.length),
+            "X-PB-Encryption-Scheme": "AES-GCM",
+            "X-PB-Decrypted-Content-Type": "text/plain;charset=UTF-8",
+            "X-PB-Highlight-Language": "plaintext",
+          },
+        })
+      }),
+    )
+
+    render(<PasteBin config={__WRANGLER_CONFIG__} />)
+
+    const editor = screen.getByRole("textbox", { name: "Paste editor" })
+    await screen.findByText("Decryption key required")
+    expect((editor as HTMLTextAreaElement).value).toStrictEqual("")
+    expect(screen.getByRole("checkbox", { name: "Client-side encryption" })).toBeChecked()
   })
 })

--- a/frontend/test/localUploads.spec.ts
+++ b/frontend/test/localUploads.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { LOCAL_UPLOADS_KEY, readLocalUploads } from "../utils/localUploads.js"
+import type { LocalUploadRecord } from "../utils/localUploads.js"
+
+function record(overrides: Partial<LocalUploadRecord> = {}): LocalUploadRecord {
+  return {
+    key: "abcd",
+    displayUrl: "https://example.com/d/abcd",
+    manageUrl: "https://example.com/abcd:password",
+    expireAt: "2026-06-18T12:00:00.000Z",
+    sizeBytes: 12,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  localStorage.clear()
+  vi.useRealTimers()
+})
+
+describe("local uploads", () => {
+  it("filters expired records and writes the active list back", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-18T12:00:00.000Z"))
+    const active = record({ key: "active", expireAt: "2026-06-18T12:00:01.000Z" })
+    const expired = record({ key: "expired", expireAt: "2026-06-18T11:59:59.000Z" })
+    localStorage.setItem(LOCAL_UPLOADS_KEY, JSON.stringify([active, expired]))
+
+    expect(readLocalUploads()).toStrictEqual([active])
+    expect(JSON.parse(localStorage.getItem(LOCAL_UPLOADS_KEY)!)).toStrictEqual([active])
+  })
+})

--- a/frontend/test/uploader.spec.ts
+++ b/frontend/test/uploader.spec.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { unzipSync } from "fflate"
+import type { PasteEditState } from "../components/PasteInputPanel.js"
+import type { PasteSetting } from "../components/PasteSettingPanel.js"
+import type { PasteResponse } from "../../shared/interfaces.js"
+import type { UploadOptions } from "../../shared/uploadPaste.js"
+
+const uploadMocks = vi.hoisted(() => ({
+  uploadNormal: vi.fn(),
+  uploadMPU: vi.fn(),
+}))
+
+vi.mock("../../shared/uploadPaste.js", () => ({
+  UploadError: class UploadError extends Error {},
+  uploadNormal: uploadMocks.uploadNormal,
+  uploadMPU: uploadMocks.uploadMPU,
+}))
+
+import { uploadPaste } from "../utils/uploader.js"
+
+const config = {
+  DEPLOY_URL: "https://example.com",
+  R2_MAX_ALLOWED: "10M",
+} as Env
+
+const pasteSetting: PasteSetting = {
+  uploadKind: "short",
+  expiration: "",
+  password: "",
+  name: "",
+  manageUrl: "",
+  doEncrypt: false,
+}
+
+function uploadResponse(): PasteResponse {
+  return {
+    url: "https://example.com/abcd",
+    manageUrl: "https://example.com/abcd:pw",
+    expirationSeconds: 300,
+    lastModifiedAt: "2025-04-30T23:55:00.000Z",
+    createdAt: "2025-04-30T23:55:00.000Z",
+    expireAt: "2025-05-01T00:00:00.000Z",
+    sizeBytes: 1,
+    location: "KV",
+  }
+}
+
+function fileEditorState(files: File[]): PasteEditState {
+  return {
+    editKind: "file",
+    editContent: "",
+    files,
+  }
+}
+
+function firstUploadOptions(): UploadOptions {
+  const calls = uploadMocks.uploadNormal.mock.calls as unknown as [string, UploadOptions][]
+  return calls[0][1]
+}
+
+describe("uploadPaste", () => {
+  beforeEach(() => {
+    uploadMocks.uploadNormal.mockReset()
+    uploadMocks.uploadMPU.mockReset()
+    uploadMocks.uploadNormal.mockResolvedValue(uploadResponse())
+  })
+
+  it("zips a single file with a relative path and keeps filenames metadata", async () => {
+    const file = new File([new TextEncoder().encode("Hello")], "normal-folder/file.txt")
+
+    await uploadPaste(pasteSetting, fileEditorState([file]), vi.fn(), config)
+
+    expect(uploadMocks.uploadNormal).toHaveBeenCalledTimes(1)
+    const options = firstUploadOptions()
+    expect(options.filenames).toStrictEqual([{ name: "normal-folder/file.txt", sizeBytes: 5 }])
+    expect(options.content).toBeInstanceOf(File)
+    expect(options.content.name).toMatch(/^1-item-\d{4}-\d{2}-\d{2}\.zip$/)
+
+    const unzipped = unzipSync(new Uint8Array(await options.content.arrayBuffer()))
+    expect(new TextDecoder().decode(unzipped["normal-folder/file.txt"])).toStrictEqual("Hello")
+  })
+
+  it("stores empty folders as zero-byte trailing-slash zip entries", async () => {
+    const emptyFolder = new File([new Uint8Array(0)], "parent-dir/sub-dir/another-empty/")
+
+    await uploadPaste(pasteSetting, fileEditorState([emptyFolder]), vi.fn(), config)
+
+    const options = firstUploadOptions()
+    expect(options.filenames).toStrictEqual([{ name: "parent-dir/sub-dir/another-empty/", sizeBytes: 0 }])
+
+    const unzipped = unzipSync(new Uint8Array(await options.content.arrayBuffer()))
+    expect(unzipped["parent-dir/sub-dir/another-empty/"]).toHaveLength(0)
+  })
+})

--- a/frontend/test/uploader.spec.ts
+++ b/frontend/test/uploader.spec.ts
@@ -53,6 +53,15 @@ function fileEditorState(files: File[]): PasteEditState {
   }
 }
 
+function textEditorState(content: string): PasteEditState {
+  return {
+    editKind: "edit",
+    editContent: content,
+    files: [],
+    editHighlightLang: "plaintext",
+  }
+}
+
 function firstUploadOptions(): UploadOptions {
   const calls = uploadMocks.uploadNormal.mock.calls as unknown as [string, UploadOptions][]
   return calls[0][1]
@@ -72,6 +81,7 @@ describe("uploadPaste", () => {
 
     expect(uploadMocks.uploadNormal).toHaveBeenCalledTimes(1)
     const options = firstUploadOptions()
+    expect(options.inferMimeType).toStrictEqual(true)
     expect(options.filenames).toStrictEqual([{ name: "normal-folder/file.txt", sizeBytes: 5 }])
     expect(options.content).toBeInstanceOf(File)
     expect(options.content.name).toMatch(/^1-item-\d{4}-\d{2}-\d{2}\.zip$/)
@@ -90,5 +100,12 @@ describe("uploadPaste", () => {
 
     const unzipped = unzipSync(new Uint8Array(await options.content.arrayBuffer()))
     expect(unzipped["parent-dir/sub-dir/another-empty/"]).toHaveLength(0)
+  })
+
+  it("does not infer mimeType for edit tab uploads", async () => {
+    await uploadPaste(pasteSetting, textEditorState("hello"), vi.fn(), config)
+
+    const options = firstUploadOptions()
+    expect(options.inferMimeType).toStrictEqual(false)
   })
 })

--- a/frontend/utils/localUploads.ts
+++ b/frontend/utils/localUploads.ts
@@ -1,0 +1,130 @@
+import type { OriginalFileInfo, PasteResponse } from "../../shared/interfaces.js"
+import { makeDisplayUrl, pasteKeyFromUrl } from "./pasteUrls.js"
+
+export interface LocalUploadRecord {
+  key: string
+  displayUrl: string
+  manageUrl: string
+  filename?: string
+  filenames?: OriginalFileInfo[]
+  expireAt: string
+  sizeBytes: number
+}
+
+export const LOCAL_UPLOADS_KEY = "pastebinWorkerLocalUploads"
+const MAX_LOCAL_UPLOADS = 50
+
+function isOriginalFileInfo(value: unknown): value is OriginalFileInfo {
+  if (typeof value !== "object" || value === null) return false
+  const record = value as Record<string, unknown>
+  return (
+    typeof record.name === "string" &&
+    typeof record.sizeBytes === "number" &&
+    Number.isFinite(record.sizeBytes) &&
+    record.sizeBytes >= 0
+  )
+}
+
+function normalizeLocalUploadRecord(value: unknown): LocalUploadRecord | undefined {
+  if (typeof value !== "object" || value === null) return undefined
+  const record = value as Record<string, unknown>
+  const displayUrl = record.displayUrl
+  const manageUrl = record.manageUrl
+  const filename = record.filename
+  const filenames = record.filenames
+  const expireAt = record.expireAt
+  const sizeBytes = record.sizeBytes
+
+  const hasRecordShape =
+    typeof displayUrl === "string" &&
+    typeof manageUrl === "string" &&
+    typeof expireAt === "string" &&
+    typeof sizeBytes === "number" &&
+    Number.isFinite(sizeBytes) &&
+    sizeBytes >= 0 &&
+    (filename === undefined || typeof filename === "string") &&
+    (filenames === undefined || (Array.isArray(filenames) && filenames.every(isOriginalFileInfo)))
+
+  if (!hasRecordShape) return undefined
+
+  let key: string
+  if (typeof record.key === "string" && record.key.length > 0) {
+    key = record.key
+  } else {
+    try {
+      key = pasteKeyFromUrl(manageUrl)
+    } catch {
+      return undefined
+    }
+  }
+
+  const normalized: LocalUploadRecord = {
+    key,
+    displayUrl,
+    manageUrl,
+    expireAt,
+    sizeBytes,
+  }
+  if (filename !== undefined) normalized.filename = filename
+  if (filenames !== undefined) normalized.filenames = filenames
+  return normalized
+}
+
+function isExpired(record: LocalUploadRecord, now = Date.now()): boolean {
+  const expireTime = new Date(record.expireAt).getTime()
+  return Number.isFinite(expireTime) && expireTime <= now
+}
+
+export function readLocalUploads(): LocalUploadRecord[] {
+  if (typeof window === "undefined") return []
+
+  try {
+    const raw = window.localStorage.getItem(LOCAL_UPLOADS_KEY)
+    if (!raw) return []
+
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    const records = parsed.flatMap((item) => {
+      const record = normalizeLocalUploadRecord(item)
+      return record === undefined ? [] : [record]
+    })
+    const activeRecords = records.filter((record) => !isExpired(record))
+    if (activeRecords.length !== records.length) {
+      writeLocalUploads(activeRecords)
+    }
+    return activeRecords
+  } catch {
+    return []
+  }
+}
+
+export function writeLocalUploads(records: LocalUploadRecord[]): LocalUploadRecord[] {
+  const nextRecords = records.slice(0, MAX_LOCAL_UPLOADS)
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(LOCAL_UPLOADS_KEY, JSON.stringify(nextRecords))
+    } catch {
+      // Local upload history is best-effort; storage failures should not break uploads.
+    }
+  }
+  return nextRecords
+}
+
+export function upsertLocalUpload(response: PasteResponse, encryptionKey?: string): LocalUploadRecord[] {
+  const record: LocalUploadRecord = {
+    key: pasteKeyFromUrl(response.url),
+    displayUrl: makeDisplayUrl(response.url, encryptionKey),
+    manageUrl: response.manageUrl,
+    filename: response.filename,
+    filenames: response.filenames,
+    expireAt: response.expireAt,
+    sizeBytes: response.sizeBytes,
+  }
+
+  const records = readLocalUploads()
+  return writeLocalUploads([record, ...records.filter((item) => item.key !== record.key)])
+}
+
+export function removeLocalUpload(key: string): LocalUploadRecord[] {
+  return writeLocalUploads(readLocalUploads().filter((item) => item.key !== key))
+}

--- a/frontend/utils/pasteUrls.ts
+++ b/frontend/utils/pasteUrls.ts
@@ -1,0 +1,16 @@
+import { parsePath } from "../../shared/parsers.js"
+
+export function withPathPrefix(url: string, prefix: string): string {
+  const u = new URL(url)
+  u.pathname = prefix + u.pathname
+  return u.toString()
+}
+
+export function makeDisplayUrl(url: string, encryptionKey?: string): string {
+  const displayUrl = withPathPrefix(url, "/d")
+  return encryptionKey ? `${displayUrl}#${encryptionKey}` : displayUrl
+}
+
+export function pasteKeyFromUrl(url: string): string {
+  return parsePath(new URL(url).pathname).name
+}

--- a/frontend/utils/uploader.ts
+++ b/frontend/utils/uploader.ts
@@ -131,6 +131,7 @@ export async function uploadPaste(
     name: pasteSetting.uploadKind === "custom" ? pasteSetting.name : undefined,
     highlightLanguage: editorState.editKind === "edit" ? editorState.editHighlightLang : undefined,
     encryptionScheme: pasteSetting.doEncrypt ? encryptionScheme : undefined,
+    inferMimeType: editorState.editKind === "file",
     manageUrl: pasteSetting.manageUrl,
   }
 

--- a/frontend/utils/uploader.ts
+++ b/frontend/utils/uploader.ts
@@ -7,6 +7,7 @@ import { encodeKey, encrypt, genKey } from "./encryption.js"
 import type { UploadOptions } from "../../shared/uploadPaste.js"
 import { UploadError, uploadMPU, uploadNormal } from "../../shared/uploadPaste.js"
 import { DEFAULT_EDIT_FILENAME } from "../../shared/constants.js"
+import { itemNoun } from "../../shared/format.js"
 import { zipSync } from "fflate"
 
 async function genAndEncrypt(scheme: EncryptionScheme, content: string | Uint8Array) {
@@ -53,7 +54,13 @@ async function zipFiles(files: File[]): Promise<File> {
     entries[zipEntryName(file, names)] = await file.bytes()
   }
   const zipped = zipSync(entries)
-  return new File([zipped], `${files.length}-files-${zipFilenameDate()}.zip`, { type: "application/zip" })
+  return new File([zipped], `${files.length}-${itemNoun(files.length)}-${zipFilenameDate()}.zip`, {
+    type: "application/zip",
+  })
+}
+
+function shouldZipFiles(files: File[]): boolean {
+  return files.length > 1 || files.some((file) => file.name.includes("/"))
 }
 
 function zipFilenameDate(): string {
@@ -79,11 +86,11 @@ export async function uploadPaste(
       if (editorState.files.length === 0) {
         throw new ErrorWithTitle("Error on Preparing Upload", "No file selected")
       }
-      originalFiles =
-        editorState.files.length > 1
-          ? editorState.files.map((file) => ({ name: file.name, sizeBytes: file.size }))
-          : undefined
-      const contentFile = editorState.files.length === 1 ? editorState.files[0] : await zipFiles(editorState.files)
+      const shouldZip = shouldZipFiles(editorState.files)
+      originalFiles = shouldZip
+        ? editorState.files.map((file) => ({ name: file.name, sizeBytes: file.size }))
+        : undefined
+      const contentFile = shouldZip ? await zipFiles(editorState.files) : editorState.files[0]
       if (pasteSetting.doEncrypt) {
         const { key, ciphertext } = await genAndEncrypt(encryptionScheme, await contentFile.bytes())
         const file = new File([ciphertext as BlobPart], contentFile.name)

--- a/frontend/utils/uploader.ts
+++ b/frontend/utils/uploader.ts
@@ -1,11 +1,13 @@
 import type { PasteSetting } from "../components/PasteSettingPanel.js"
 import type { PasteEditState } from "../components/PasteInputPanel.js"
-import { ErrorWithTitle } from "./utils.js"
-import type { PasteResponse } from "../../shared/interfaces.js"
+import { ErrorWithTitle, verifyFileSize } from "./utils.js"
+import type { OriginalFileInfo, PasteResponse } from "../../shared/interfaces.js"
 import type { EncryptionScheme } from "./encryption.js"
 import { encodeKey, encrypt, genKey } from "./encryption.js"
 import type { UploadOptions } from "../../shared/uploadPaste.js"
 import { UploadError, uploadMPU, uploadNormal } from "../../shared/uploadPaste.js"
+import { DEFAULT_EDIT_FILENAME } from "../../shared/constants.js"
+import { zipSync } from "fflate"
 
 async function genAndEncrypt(scheme: EncryptionScheme, content: string | Uint8Array) {
   const key = await genKey(scheme)
@@ -18,10 +20,49 @@ const encryptionScheme: EncryptionScheme = "AES-GCM"
 
 const mpuChunkSize = 5 * 1024 * 1024
 const mpuThreshold = 5 * 1024 * 1024
+const zipMtime = new Date(2026, 0, 1, 0, 0, 0)
 
 export interface UploadProgress {
   doneBytes: number
   totalBytes: number
+}
+
+function zipEntryName(file: File, existing: Set<string>): string {
+  if (!existing.has(file.name)) {
+    existing.add(file.name)
+    return file.name
+  }
+
+  const dot = file.name.lastIndexOf(".")
+  const basename = dot > 0 ? file.name.slice(0, dot) : file.name
+  const ext = dot > 0 ? file.name.slice(dot) : ""
+  let index = 2
+  while (true) {
+    const candidate = `${basename} (${index})${ext}`
+    if (!existing.has(candidate)) {
+      existing.add(candidate)
+      return candidate
+    }
+    index += 1
+  }
+}
+
+async function zipFiles(files: File[]): Promise<File> {
+  const entries: Record<string, Uint8Array> = {}
+  const names = new Set<string>()
+  for (const file of files) {
+    entries[zipEntryName(file, names)] = await file.bytes()
+  }
+  const zipped = zipSync(entries, { mtime: zipMtime })
+  return new File([zipped], `paste-files-${zipFilenameDate()}.zip`, { type: "application/zip" })
+}
+
+function zipFilenameDate(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, "0")
+  const day = String(now.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
 }
 
 export async function uploadPaste(
@@ -32,19 +73,26 @@ export async function uploadPaste(
   onProgress?: (progress: UploadProgress | undefined) => void,
   signal?: AbortSignal,
 ): Promise<PasteResponse> {
+  let originalFiles: OriginalFileInfo[] | undefined
+
   async function constructContent(): Promise<File> {
     if (editorState.editKind === "file") {
-      if (editorState.file === null) {
+      if (editorState.files.length === 0) {
         throw new ErrorWithTitle("Error on Preparing Upload", "No file selected")
       }
+      originalFiles =
+        editorState.files.length > 1
+          ? editorState.files.map((file) => ({ name: file.name, sizeBytes: file.size }))
+          : undefined
+      const contentFile = editorState.files.length === 1 ? editorState.files[0] : await zipFiles(editorState.files)
       if (pasteSetting.doEncrypt) {
-        const { key, ciphertext } = await genAndEncrypt(encryptionScheme, await editorState.file.bytes())
-        const file = new File([ciphertext as BlobPart], editorState.file.name)
+        const { key, ciphertext } = await genAndEncrypt(encryptionScheme, await contentFile.bytes())
+        const file = new File([ciphertext as BlobPart], contentFile.name)
         onEncryptionKeyChange(key)
         return file
       } else {
         onEncryptionKeyChange(undefined)
-        return editorState.file
+        return contentFile
       }
     } else {
       if (editorState.editContent.length === 0) {
@@ -53,16 +101,23 @@ export async function uploadPaste(
       if (pasteSetting.doEncrypt) {
         const { key, ciphertext } = await genAndEncrypt(encryptionScheme, editorState.editContent)
         onEncryptionKeyChange(key)
-        return new File([ciphertext as BlobPart], editorState.editFilename || "")
+        return new File([ciphertext as BlobPart], editorState.editFilename || DEFAULT_EDIT_FILENAME)
       } else {
         onEncryptionKeyChange(undefined)
-        return new File([editorState.editContent], editorState.editFilename || "")
+        return new File([editorState.editContent], editorState.editFilename || DEFAULT_EDIT_FILENAME)
       }
     }
   }
 
+  const content = await constructContent()
+  const [contentSizeOk, contentSizeMsg] = verifyFileSize(content.size, config)
+  if (!contentSizeOk) {
+    throw new ErrorWithTitle("Error on Preparing Upload", contentSizeMsg)
+  }
+
   const options: UploadOptions = {
-    content: await constructContent(),
+    content,
+    filenames: originalFiles,
     isUpdate: pasteSetting.uploadKind === "manage",
     isPrivate: pasteSetting.uploadKind === "long",
     password: pasteSetting.password.length ? pasteSetting.password : undefined,

--- a/frontend/utils/uploader.ts
+++ b/frontend/utils/uploader.ts
@@ -20,7 +20,6 @@ const encryptionScheme: EncryptionScheme = "AES-GCM"
 
 const mpuChunkSize = 5 * 1024 * 1024
 const mpuThreshold = 5 * 1024 * 1024
-const zipMtime = new Date(2026, 0, 1, 0, 0, 0)
 
 export interface UploadProgress {
   doneBytes: number
@@ -53,8 +52,8 @@ async function zipFiles(files: File[]): Promise<File> {
   for (const file of files) {
     entries[zipEntryName(file, names)] = await file.bytes()
   }
-  const zipped = zipSync(entries, { mtime: zipMtime })
-  return new File([zipped], `paste-files-${zipFilenameDate()}.zip`, { type: "application/zip" })
+  const zipped = zipSync(entries)
+  return new File([zipped], `${files.length}-files-${zipFilenameDate()}.zip`, { type: "application/zip" })
 }
 
 function zipFilenameDate(): string {

--- a/frontend/utils/useLocalUploads.ts
+++ b/frontend/utils/useLocalUploads.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react"
+
+import type { PasteResponse } from "../../shared/interfaces.js"
+import type { LocalUploadRecord } from "./localUploads.js"
+import { LOCAL_UPLOADS_KEY, readLocalUploads, removeLocalUpload, upsertLocalUpload } from "./localUploads.js"
+
+export function useLocalUploads() {
+  const [localUploads, setLocalUploads] = useState<LocalUploadRecord[]>([])
+
+  useEffect(() => {
+    setLocalUploads(readLocalUploads())
+  }, [])
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === LOCAL_UPLOADS_KEY) {
+        setLocalUploads(readLocalUploads())
+      }
+    }
+
+    window.addEventListener("storage", onStorage)
+    return () => window.removeEventListener("storage", onStorage)
+  }, [])
+
+  function rememberLocalUpload(response: PasteResponse, encryptionKey?: string) {
+    setLocalUploads(upsertLocalUpload(response, encryptionKey))
+  }
+
+  function removeLocalUploadByKey(key: string) {
+    setLocalUploads(removeLocalUpload(key))
+  }
+
+  return {
+    localUploads,
+    rememberLocalUpload,
+    removeLocalUploadByKey,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "fflate": "^0.8.3",
     "github-slugger": "^2.0.0",
     "highlight.js": "^11.11.1",
+    "lean-qr": "^2.7.1",
     "marked": "^18.0.5",
     "mime": "^4.1.0",
     "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "printWidth": 120
   },
   "dependencies": {
-    "@mjackson/multipart-parser": "^0.10.1",
     "@tailwindcss/vite": "^4.3.0",
     "@types/bcrypt": "^6.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "bcrypt-ts": "^8.0.1",
+    "fflate": "^0.8.3",
     "github-slugger": "^2.0.0",
     "highlight.js": "^11.11.1",
     "marked": "^18.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@mjackson/multipart-parser':
-        specifier: ^0.10.1
-        version: 0.10.1
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
@@ -26,6 +23,9 @@ importers:
       bcrypt-ts:
         specifier: ^8.0.1
         version: 8.0.1
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -789,12 +789,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@mjackson/headers@0.11.1':
-    resolution: {integrity: sha512-uXXhd4rtDdDwkqAuGef1nuafkCa1NlTmEc1Jzc0NL4YiA1yON1NFXuqJ3hOuKvNKQwkiDwdD+JJlKVyz4dunFA==}
-
-  '@mjackson/multipart-parser@0.10.1':
-    resolution: {integrity: sha512-cHMD6+ErH/DrEfC0N6Ru/+1eAdavxdV0C35PzSb5/SD7z3XoaDMc16xPJcb8CahWjSpqHY+Too9sAb6/UNuq7A==}
-
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
@@ -1480,6 +1474,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2883,12 +2880,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mjackson/headers@0.11.1': {}
-
-  '@mjackson/multipart-parser@0.10.1':
-    dependencies:
-      '@mjackson/headers': 0.11.1
-
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -3557,6 +3548,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      lean-qr:
+        specifier: ^2.7.1
+        version: 2.7.1
       marked:
         specifier: ^18.0.5
         version: 18.0.5
@@ -1653,6 +1656,10 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lean-qr@2.7.1:
+    resolution: {integrity: sha512-4WfYs9t1jpiF6nDRxe9LFlWzRhvVeiV3tpsjAkrijHx5dtrF0E4dupvjJX3SUoS18CAaU6QF2gSZILO10z8utA==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3730,6 +3737,8 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@4.1.5: {}
+
+  lean-qr@2.7.1: {}
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  stringify-entities: 4.0.2
-
 importers:
 
   .:
@@ -611,89 +608,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -851,36 +864,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -956,24 +975,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1673,24 +1696,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  esbuild: true
+  msw: true
+  sharp: true
+  workerd: true

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -9,3 +9,5 @@ export const MAX_URL_REDIRECT_LEN = 2000
 export const PASSWD_SEP = ":"
 export const MAX_AUTO_FETCH_BYTES = 256 * 1024
 export const DEFAULT_EDIT_FILENAME = "Untitled"
+export const TEXT_MIME_TYPE = "text/plain;charset=UTF-8"
+export const BINARY_MIME_TYPE = "application/octet-stream"

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -8,3 +8,4 @@ export const MIN_PASSWD_LEN = 8
 export const MAX_URL_REDIRECT_LEN = 2000
 export const PASSWD_SEP = ":"
 export const MAX_AUTO_FETCH_BYTES = 256 * 1024
+export const DEFAULT_EDIT_FILENAME = "Untitled"

--- a/shared/filename.ts
+++ b/shared/filename.ts
@@ -1,0 +1,5 @@
+import { DEFAULT_EDIT_FILENAME } from "./constants.js"
+
+export function filenameForTitle(filename: string | undefined): string | undefined {
+  return filename === DEFAULT_EDIT_FILENAME ? undefined : filename
+}

--- a/shared/format.ts
+++ b/shared/format.ts
@@ -1,0 +1,7 @@
+export function itemNoun(count: number): "item" | "items" {
+  return count === 1 ? "item" : "items"
+}
+
+export function itemCountLabel(count: number): string {
+  return `${count} ${itemNoun(count)}`
+}

--- a/shared/interfaces.ts
+++ b/shared/interfaces.ts
@@ -15,6 +15,7 @@ export interface MetaResponse {
   location: PasteLocation
   filename?: string
   filenames?: OriginalFileInfo[]
+  mimeType?: string
   highlightLanguage?: string
   encryptionScheme?: string
 }

--- a/shared/interfaces.ts
+++ b/shared/interfaces.ts
@@ -2,6 +2,11 @@
 
 export type PasteLocation = "KV" | "R2"
 
+export interface OriginalFileInfo {
+  name: string
+  sizeBytes: number
+}
+
 export interface MetaResponse {
   lastModifiedAt: string
   createdAt: string
@@ -9,6 +14,7 @@ export interface MetaResponse {
   sizeBytes: number
   location: PasteLocation
   filename?: string
+  filenames?: OriginalFileInfo[]
   highlightLanguage?: string
   encryptionScheme?: string
 }

--- a/shared/test/uploadPaste.spec.ts
+++ b/shared/test/uploadPaste.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { UploadError, uploadMPU, uploadNormal } from "../uploadPaste.js"
+import { BINARY_MIME_TYPE, TEXT_MIME_TYPE } from "../constants.js"
 
 const API_URL = "https://example.com"
 
@@ -119,7 +120,70 @@ describe("uploadNormal", () => {
     expect(fd.get("lang")).toStrictEqual("ts")
     expect(fd.get("p")).toStrictEqual("1")
     expect(fd.get("filenames")).toStrictEqual(JSON.stringify([{ name: "a.txt", sizeBytes: 4 }]))
+    expect(fd.get("mimeType")).toBeNull()
     expect(fd.get("c")).toBeInstanceOf(File)
+  })
+
+  it("adds mimeType for extensionless normal uploads without lang or encryption", async () => {
+    const calls = setupXhr(() => ({
+      status: 200,
+      body: JSON.stringify({ url: "https://example.com/abcd", manageUrl: "https://example.com/abcd:pw" }),
+    }))
+
+    await uploadNormal(API_URL, {
+      content: new File([new Uint8Array([1, 2, 0, 3])], "blob"),
+      inferMimeType: true,
+      isUpdate: false,
+    })
+
+    expect((calls[0].body as FormData).get("mimeType")).toStrictEqual(BINARY_MIME_TYPE)
+  })
+
+  it("checks the first 256 bytes when inferring mimeType", async () => {
+    const calls = setupXhr(() => ({
+      status: 200,
+      body: JSON.stringify({ url: "https://example.com/abcd", manageUrl: "https://example.com/abcd:pw" }),
+    }))
+    const content = new Uint8Array(300).fill(1)
+    content[200] = 0
+
+    await uploadNormal(API_URL, {
+      content: new File([content], "blob"),
+      inferMimeType: true,
+      isUpdate: false,
+    })
+
+    expect((calls[0].body as FormData).get("mimeType")).toStrictEqual(BINARY_MIME_TYPE)
+  })
+
+  it("adds text mimeType for extensionless normal text uploads", async () => {
+    const calls = setupXhr(() => ({
+      status: 200,
+      body: JSON.stringify({ url: "https://example.com/abcd", manageUrl: "https://example.com/abcd:pw" }),
+    }))
+
+    await uploadNormal(API_URL, {
+      content: new File(["hello"], "blob"),
+      inferMimeType: true,
+      isUpdate: false,
+    })
+
+    expect((calls[0].body as FormData).get("mimeType")).toStrictEqual(TEXT_MIME_TYPE)
+  })
+
+  it("skips mimeType when inference is disabled", async () => {
+    const calls = setupXhr(() => ({
+      status: 200,
+      body: JSON.stringify({ url: "https://example.com/abcd", manageUrl: "https://example.com/abcd:pw" }),
+    }))
+
+    await uploadNormal(API_URL, {
+      content: new File([new Uint8Array([1, 2, 0, 3])], "blob"),
+      inferMimeType: false,
+      isUpdate: false,
+    })
+
+    expect((calls[0].body as FormData).get("mimeType")).toBeNull()
   })
 
   it("PUTs to manageUrl on update and skips name field", async () => {
@@ -243,6 +307,20 @@ describe("uploadMPU", () => {
     expect(fd.get("lang")).toStrictEqual("rust")
     expect(fd.get("encryption-scheme")).toStrictEqual("AES-GCM")
     expect(fd.get("filenames")).toStrictEqual(JSON.stringify([{ name: "a.bin", sizeBytes: 6 }]))
+    expect(fd.get("mimeType")).toBeNull()
+  })
+
+  it("adds mimeType on MPU complete for extensionless uploads without lang or encryption", async () => {
+    const { fetchCalls } = setupHappyPath(1)
+
+    await uploadMPU(API_URL, 16, {
+      content: new File([new Uint8Array([1, 2, 0, 3])], "blob"),
+      inferMimeType: true,
+      isUpdate: false,
+    })
+
+    const completeReq = fetchCalls.find((c) => c.url.includes("/mpu/complete"))!
+    expect((completeReq.body as FormData).get("mimeType")).toStrictEqual(BINARY_MIME_TYPE)
   })
 
   it("uses create-update endpoint and PUT on update with manageUrl password", async () => {

--- a/shared/test/uploadPaste.spec.ts
+++ b/shared/test/uploadPaste.spec.ts
@@ -96,6 +96,7 @@ describe("uploadNormal", () => {
 
     const resp = await uploadNormal(API_URL, {
       content: makeFile(16, "x.txt"),
+      filenames: [{ name: "a.txt", sizeBytes: 4 }],
       isUpdate: false,
       isPrivate: true,
       password: "pw",
@@ -117,6 +118,7 @@ describe("uploadNormal", () => {
     expect(fd.get("encryption-scheme")).toStrictEqual("AES-GCM")
     expect(fd.get("lang")).toStrictEqual("ts")
     expect(fd.get("p")).toStrictEqual("1")
+    expect(fd.get("filenames")).toStrictEqual(JSON.stringify([{ name: "a.txt", sizeBytes: 4 }]))
     expect(fd.get("c")).toBeInstanceOf(File)
   })
 
@@ -206,6 +208,7 @@ describe("uploadMPU", () => {
         password: "pw",
         highlightLanguage: "rust",
         encryptionScheme: "AES-GCM",
+        filenames: [{ name: "a.bin", sizeBytes: 6 }],
         expire: "1d",
       },
       progress,
@@ -239,6 +242,7 @@ describe("uploadMPU", () => {
     expect(fd.get("s")).toStrictEqual("pw")
     expect(fd.get("lang")).toStrictEqual("rust")
     expect(fd.get("encryption-scheme")).toStrictEqual("AES-GCM")
+    expect(fd.get("filenames")).toStrictEqual(JSON.stringify([{ name: "a.bin", sizeBytes: 6 }]))
   })
 
   it("uses create-update endpoint and PUT on update with manageUrl password", async () => {

--- a/shared/uploadPaste.ts
+++ b/shared/uploadPaste.ts
@@ -2,6 +2,7 @@
 
 import type { MPUCreateResponse, OriginalFileInfo, PasteResponse } from "./interfaces.js"
 import type { EncryptionScheme } from "../frontend/utils/encryption.js"
+import { BINARY_MIME_TYPE, TEXT_MIME_TYPE } from "./constants.js"
 import { parsePath } from "./parsers.js"
 
 export class UploadError extends Error {
@@ -26,11 +27,13 @@ export interface UploadOptions {
 
   highlightLanguage?: string
   encryptionScheme?: EncryptionScheme
+  inferMimeType?: boolean
   expire?: string
   manageUrl?: string
 }
 
 export const DEFAULT_MPU_CONCURRENCY = 8
+const MIME_TYPE_SNIFF_BYTES = 256
 
 interface XhrSendOptions {
   method: "POST" | "PUT"
@@ -121,6 +124,31 @@ async function runWithConcurrency<T>(
   return results
 }
 
+function filenameHasExtension(filename: string): boolean {
+  const lastSlash = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"))
+  const basename = filename.slice(lastSlash + 1)
+  return basename.lastIndexOf(".") > 0
+}
+
+async function inferMimeTypeFromContent(content: File): Promise<string | undefined> {
+  if (filenameHasExtension(content.name)) return undefined
+  const bytes = new Uint8Array(await content.slice(0, MIME_TYPE_SNIFF_BYTES).arrayBuffer())
+  return bytes.includes(0) ? BINARY_MIME_TYPE : TEXT_MIME_TYPE
+}
+
+async function maybeAddMimeType(
+  fd: FormData,
+  content: File,
+  encryptionScheme: EncryptionScheme | undefined,
+  inferMimeType: boolean | undefined,
+): Promise<void> {
+  if (inferMimeType !== true) return
+  if (encryptionScheme !== undefined) return
+
+  const mimeType = await inferMimeTypeFromContent(content)
+  if (mimeType !== undefined) fd.set("mimeType", mimeType)
+}
+
 // note that apiUrl should be manageUrl when isUpload
 export async function uploadNormal(
   apiUrl: string,
@@ -133,6 +161,7 @@ export async function uploadNormal(
     name,
     highlightLanguage,
     encryptionScheme,
+    inferMimeType,
     expire,
     manageUrl,
   }: UploadOptions,
@@ -143,6 +172,7 @@ export async function uploadNormal(
 
   // typescript cannot handle overload on union types
   fd.set("c", content)
+  await maybeAddMimeType(fd, content, encryptionScheme, inferMimeType)
   if (filenames !== undefined) fd.set("filenames", JSON.stringify(filenames))
 
   if (isUpdate && manageUrl === undefined) {
@@ -184,6 +214,7 @@ export async function uploadMPU(
     name,
     highlightLanguage,
     encryptionScheme,
+    inferMimeType,
     expire,
     manageUrl,
   }: UploadOptions,
@@ -293,6 +324,7 @@ export async function uploadMPU(
     completeUrl.searchParams.set("key", createKey)
     completeUrl.searchParams.set("uploadId", createUploadId)
     completeFormData.set("c", new File([JSON.stringify(uploadedParts)], content.name))
+    await maybeAddMimeType(completeFormData, content, encryptionScheme, inferMimeType)
     if (filenames !== undefined) {
       completeFormData.set("filenames", JSON.stringify(filenames))
     }

--- a/shared/uploadPaste.ts
+++ b/shared/uploadPaste.ts
@@ -1,6 +1,6 @@
 // we will move this file to a shared directory later
 
-import type { MPUCreateResponse, PasteResponse } from "./interfaces.js"
+import type { MPUCreateResponse, OriginalFileInfo, PasteResponse } from "./interfaces.js"
 import type { EncryptionScheme } from "../frontend/utils/encryption.js"
 import { parsePath } from "./parsers.js"
 
@@ -15,6 +15,7 @@ export class UploadError extends Error {
 
 export interface UploadOptions {
   content: File
+  filenames?: OriginalFileInfo[]
   isUpdate: boolean
 
   // we allow it to be undefined for convenience
@@ -125,6 +126,7 @@ export async function uploadNormal(
   apiUrl: string,
   {
     content,
+    filenames,
     isUpdate,
     isPrivate,
     password,
@@ -141,6 +143,7 @@ export async function uploadNormal(
 
   // typescript cannot handle overload on union types
   fd.set("c", content)
+  if (filenames !== undefined) fd.set("filenames", JSON.stringify(filenames))
 
   if (isUpdate && manageUrl === undefined) {
     throw TypeError("uploadMPU: no manageUrl specified in update")
@@ -174,6 +177,7 @@ export async function uploadMPU(
   chunkSize: number,
   {
     content,
+    filenames,
     isUpdate,
     isPrivate,
     password,
@@ -289,6 +293,9 @@ export async function uploadMPU(
     completeUrl.searchParams.set("key", createKey)
     completeUrl.searchParams.set("uploadId", createUploadId)
     completeFormData.set("c", new File([JSON.stringify(uploadedParts)], content.name))
+    if (filenames !== undefined) {
+      completeFormData.set("filenames", JSON.stringify(filenames))
+    }
     if (expire !== undefined) {
       completeFormData.set("e", expire)
     }

--- a/worker/common.ts
+++ b/worker/common.ts
@@ -1,7 +1,7 @@
 import { CHAR_GEN } from "../shared/constants.js"
 
-export function decode(arrayBuffer: ArrayBuffer): string {
-  return new TextDecoder().decode(arrayBuffer)
+export function decode(buffer: ArrayBuffer | ArrayBufferView<ArrayBufferLike>): string {
+  return new TextDecoder().decode(buffer)
 }
 
 export function btoa_utf8(value: string): string {
@@ -37,14 +37,19 @@ export function dateToUnix(date: Date): number {
   return Math.floor(date.getTime() / 1000)
 }
 
-export function genRandStr(len: number) {
-  // TODO: switch to Web Crypto random generator
-  let str = ""
-  const numOfRand = CHAR_GEN.length
+export function genRandStr(len: number): string {
+  let str = "";
+  const numOfRand = CHAR_GEN.length;
+
+  const randomValues = new Uint32Array(len);
+  crypto.getRandomValues(randomValues);
+
   for (let i = 0; i < len; i++) {
-    str += CHAR_GEN.charAt(Math.floor(Math.random() * numOfRand))
+    const randomIndex = randomValues[i] % numOfRand;
+    str += CHAR_GEN.charAt(randomIndex);
   }
-  return str
+
+  return str;
 }
 
 // Workers extension to SubtleCrypto, mirrored from worker-configuration.d.ts.

--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -11,6 +11,7 @@ import { MAX_URL_REDIRECT_LEN } from "../../shared/constants.js"
 import { filenameForTitle } from "../../shared/filename.js"
 import manifest from "../../dist/frontend/.vite/ssr-manifest.json"
 import { getAssetPaths, renderCssLinks, DARK_MODE_SCRIPT } from "../ssrUtils.js"
+import { itemCountLabel } from "../../shared/format.js"
 
 type Headers = Record<string, string>
 
@@ -299,7 +300,7 @@ export async function handleGet(request: Request, env: Env, ctx: ExecutionContex
     pageUrl.search = ""
     pageUrl.pathname = "/display.html"
     const displayName = item.metadata.filenames?.length
-      ? `${item.metadata.filenames.length} files`
+      ? itemCountLabel(item.metadata.filenames.length)
       : filenameForTitle(item.metadata.filename)
     const titleFilename = filenameForTitle(filename)
     const page = decode(await (await env.ASSETS.fetch(pageUrl)).arrayBuffer()).replace(

--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -7,7 +7,7 @@ import { makeMarkdown } from "../pages/markdown.js"
 import type { PasteMetadata, PasteWithMetadata } from "../storage/storage.js"
 import { getPaste, getPasteMetadata, metaResponseFromMetadata } from "../storage/storage.js"
 import { parsePath } from "../../shared/parsers.js"
-import { MAX_URL_REDIRECT_LEN } from "../../shared/constants.js"
+import { BINARY_MIME_TYPE, MAX_URL_REDIRECT_LEN, TEXT_MIME_TYPE } from "../../shared/constants.js"
 import { filenameForTitle } from "../../shared/filename.js"
 import manifest from "../../dist/frontend/.vite/ssr-manifest.json"
 import { getAssetPaths, renderCssLinks, DARK_MODE_SCRIPT } from "../ssrUtils.js"
@@ -64,7 +64,7 @@ async function handleStaticPages(request: Request, env: Env, _: ExecutionContext
     }
     return new Response(getCurlIndexMarkdown(env), {
       headers: {
-        "Content-Type": "text/plain;charset=UTF-8",
+        "Content-Type": TEXT_MIME_TYPE,
         Vary: "User-Agent",
         ...staticPageCacheHeader(env),
       },
@@ -162,7 +162,7 @@ ${DARK_MODE_SCRIPT}
       const wantsMarkdown = isExplicitMd || isCurl
       return new Response(wantsMarkdown ? docMd : renderDocAsHtml(docMd), {
         headers: {
-          "Content-Type": wantsMarkdown ? "text/plain;charset=UTF-8" : "text/html;charset=UTF-8",
+          "Content-Type": wantsMarkdown ? TEXT_MIME_TYPE : "text/html;charset=UTF-8",
           Vary: "User-Agent",
           ...staticPageCacheHeader(env),
         },
@@ -206,16 +206,17 @@ export async function handleGet(request: Request, env: Env, ctx: ExecutionContex
   }
 
   const disallowedMimes = env.DISALLOWED_MIME_FOR_PASTE as readonly string[]
-  const sanitize = (m: string) => (disallowedMimes.includes(m) ? "text/plain;charset=UTF-8" : m)
+  const sanitize = (m: string) => (disallowedMimes.includes(m) ? TEXT_MIME_TYPE : m)
 
   const realMime =
     url.searchParams.get("mime") ||
     (ext && mime.getType(ext)) ||
     (item.metadata.filename && mime.getType(item.metadata.filename)) ||
-    "text/plain;charset=UTF-8"
+    item.metadata.mimeType ||
+    TEXT_MIME_TYPE
 
   let inferred_mime = item.metadata.encryptionScheme
-    ? url.searchParams.get("mime") || (ext && mime.getType(ext)) || "application/octet-stream"
+    ? url.searchParams.get("mime") || (ext && mime.getType(ext)) || BINARY_MIME_TYPE
     : realMime
   inferred_mime = sanitize(inferred_mime)
 

--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -278,7 +278,8 @@ export async function handleGet(request: Request, env: Env, ctx: ExecutionContex
   if (role === "d") {
     try {
       const { renderDisplayPage } = await import("../pages/display.js")
-      const page = await renderDisplayPage(env, name, filename, ext, item.paste, item.metadata)
+      const urlLang = url.searchParams.get("lang") || undefined
+      const page = await renderDisplayPage(env, name, filename, ext, urlLang, item.paste, item.metadata)
       if (page) {
         return new Response(isHead ? null : page, {
           headers: {

--- a/worker/handlers/handleRead.ts
+++ b/worker/handlers/handleRead.ts
@@ -8,6 +8,7 @@ import type { PasteMetadata, PasteWithMetadata } from "../storage/storage.js"
 import { getPaste, getPasteMetadata, metaResponseFromMetadata } from "../storage/storage.js"
 import { parsePath } from "../../shared/parsers.js"
 import { MAX_URL_REDIRECT_LEN } from "../../shared/constants.js"
+import { filenameForTitle } from "../../shared/filename.js"
 import manifest from "../../dist/frontend/.vite/ssr-manifest.json"
 import { getAssetPaths, renderCssLinks, DARK_MODE_SCRIPT } from "../ssrUtils.js"
 
@@ -297,9 +298,13 @@ export async function handleGet(request: Request, env: Env, ctx: ExecutionContex
     const pageUrl = url
     pageUrl.search = ""
     pageUrl.pathname = "/display.html"
+    const displayName = item.metadata.filenames?.length
+      ? `${item.metadata.filenames.length} files`
+      : filenameForTitle(item.metadata.filename)
+    const titleFilename = filenameForTitle(filename)
     const page = decode(await (await env.ASSETS.fetch(pageUrl)).arrayBuffer()).replace(
       "{{PASTE_NAME}}",
-      name + (filename ? " / " + filename : ext ? ext : item.metadata.filename ? " / " + item.metadata.filename : ""),
+      name + (titleFilename ? " / " + titleFilename : ext ? ext : displayName ? " / " + displayName : ""),
     )
     return new Response(isHead ? null : page, {
       headers: {

--- a/worker/handlers/handleWrite.ts
+++ b/worker/handlers/handleWrite.ts
@@ -7,7 +7,14 @@ import {
   pasteNameAvailable,
   updatePaste,
 } from "../storage/storage.js"
-import { DEFAULT_PASSWD_LEN, PASTE_NAME_LEN, PRIVATE_PASTE_NAME_LEN, PASSWD_SEP } from "../../shared/constants.js"
+import {
+  BINARY_MIME_TYPE,
+  DEFAULT_PASSWD_LEN,
+  PASTE_NAME_LEN,
+  PRIVATE_PASTE_NAME_LEN,
+  PASSWD_SEP,
+  TEXT_MIME_TYPE,
+} from "../../shared/constants.js"
 import { parsePath, parseSize, parseExpiration } from "../../shared/parsers.js"
 import { verifyName, verifyPassword } from "../../shared/verify.js"
 import type { OriginalFileInfo, PasteResponse } from "../../shared/interfaces.js"
@@ -54,6 +61,12 @@ function isOriginalFileInfo(value: unknown): value is OriginalFileInfo {
     Number.isFinite(record.sizeBytes) &&
     record.sizeBytes >= 0
   )
+}
+
+function parseMimeType(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined
+  if (raw === TEXT_MIME_TYPE || raw === BINARY_MIME_TYPE) return raw
+  throw new WorkerError(400, "invalid mimeType metadata")
 }
 
 async function multipartToMap(req: Request, sizeLimit: string): Promise<Map<string, ParsedMultipartPart>> {
@@ -148,6 +161,7 @@ export async function handlePostOrPut(
   const encryptionScheme: string | undefined = parts.get("encryption-scheme")?.contentAsString()
   const highlightLanguage = parts.get("lang")?.contentAsString()
   const filenames = parseOriginalFileInfos(parts.get("filenames")?.contentAsString())
+  const mimeType = parseMimeType(parts.get("mimeType")?.contentAsString())
   const expire = expireFromForm ? expireFromForm : env.DEFAULT_EXPIRATION
 
   const uploadedParts = isMPUComplete ? (JSON.parse(contentAsString()) as R2UploadedPart[]) : undefined
@@ -230,6 +244,7 @@ export async function handlePostOrPut(
       contentLength: r2Object?.size || contentLength,
       filename,
       filenames,
+      mimeType,
       highlightLanguage,
       encryptionScheme,
       isMPUComplete,
@@ -269,6 +284,7 @@ export async function handlePostOrPut(
       passwd: password,
       filename,
       filenames,
+      mimeType,
       highlightLanguage,
       contentLength: r2Object?.size || contentLength,
       encryptionScheme,

--- a/worker/handlers/handleWrite.ts
+++ b/worker/handlers/handleWrite.ts
@@ -10,8 +10,7 @@ import {
 import { DEFAULT_PASSWD_LEN, PASTE_NAME_LEN, PRIVATE_PASTE_NAME_LEN, PASSWD_SEP } from "../../shared/constants.js"
 import { parsePath, parseSize, parseExpiration } from "../../shared/parsers.js"
 import { verifyName, verifyPassword } from "../../shared/verify.js"
-import type { PasteResponse } from "../../shared/interfaces.js"
-import { MaxFileSizeExceededError, MultipartParseError, parseMultipartRequest } from "@mjackson/multipart-parser"
+import type { OriginalFileInfo, PasteResponse } from "../../shared/interfaces.js"
 import {
   handleMPUAbort,
   handleMPUComplete,
@@ -22,45 +21,79 @@ import {
 
 interface ParsedMultipartPart {
   filename?: string
-  content: ReadableStream | ArrayBuffer
+  content: ArrayBuffer
   contentAsString: () => string
   contentLength: number
 }
 
+function parseOriginalFileInfos(raw: string | undefined): OriginalFileInfo[] | undefined {
+  if (!raw) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new WorkerError(400, "invalid filenames metadata")
+  }
+  if (!Array.isArray(parsed)) {
+    throw new WorkerError(400, "invalid filenames metadata")
+  }
+  return parsed.map((item) => {
+    if (!isOriginalFileInfo(item)) {
+      throw new WorkerError(400, "invalid filenames metadata")
+    }
+    return { name: item.name, sizeBytes: item.sizeBytes }
+  })
+}
+
+function isOriginalFileInfo(value: unknown): value is OriginalFileInfo {
+  if (typeof value !== "object" || value === null) return false
+  const record = value as Record<string, unknown>
+  return (
+    typeof record.name === "string" &&
+    typeof record.sizeBytes === "number" &&
+    Number.isFinite(record.sizeBytes) &&
+    record.sizeBytes >= 0
+  )
+}
+
 async function multipartToMap(req: Request, sizeLimit: string): Promise<Map<string, ParsedMultipartPart>> {
   const partsMap = new Map<string, ParsedMultipartPart>()
+  const maxPartSize = parseSize(sizeLimit)!
+  let formData: FormData
+
   try {
-    for await (const part of parseMultipartRequest(req, { maxFileSize: parseSize(sizeLimit)! })) {
-      if (part.name) {
-        if (part.isFile) {
-          const arrayBuffer = part.arrayBuffer
-          partsMap.set(part.name, {
-            filename: part.filename,
-            content: arrayBuffer,
-            contentLength: arrayBuffer.byteLength,
-            contentAsString: () => decode(arrayBuffer),
-          })
-        } else {
-          const arrayBuffer = part.arrayBuffer
-          partsMap.set(part.name, {
-            filename: part.filename,
-            content: arrayBuffer,
-            contentAsString: () => decode(arrayBuffer),
-            contentLength: arrayBuffer.byteLength,
-          })
-        }
-      }
-    }
+    formData = await req.formData()
   } catch (err) {
-    if (err instanceof MaxFileSizeExceededError) {
-      throw new WorkerError(413, `payload too large (max ${sizeLimit} allowed)`)
-    } else if (err instanceof MultipartParseError) {
-      console.warn("Failed to parse multipart request:", err.message)
-      throw new WorkerError(400, "Failed to parse multipart request")
+    console.warn("Failed to parse multipart request:", err instanceof Error ? err.message : err)
+    throw new WorkerError(400, "Failed to parse multipart request")
+  }
+
+  for (const [name, value] of formData.entries()) {
+    if (typeof value === "string") {
+      const bytes = new TextEncoder().encode(value)
+      if (bytes.byteLength > maxPartSize) {
+        throw new WorkerError(413, `payload too large (max ${sizeLimit} allowed)`)
+      }
+      const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      partsMap.set(name, {
+        content: arrayBuffer,
+        contentLength: bytes.byteLength,
+        contentAsString: () => value,
+      })
     } else {
-      throw err
+      const arrayBuffer = await value.arrayBuffer()
+      if (arrayBuffer.byteLength > maxPartSize) {
+        throw new WorkerError(413, `payload too large (max ${sizeLimit} allowed)`)
+      }
+      partsMap.set(name, {
+        filename: value.name,
+        content: arrayBuffer,
+        contentLength: arrayBuffer.byteLength,
+        contentAsString: () => decode(arrayBuffer),
+      })
     }
   }
+
   return partsMap
 }
 
@@ -114,6 +147,7 @@ export async function handlePostOrPut(
   const expireFromForm: string | undefined = parts.get("e")?.contentAsString()
   const encryptionScheme: string | undefined = parts.get("encryption-scheme")?.contentAsString()
   const highlightLanguage = parts.get("lang")?.contentAsString()
+  const filenames = parseOriginalFileInfos(parts.get("filenames")?.contentAsString())
   const expire = expireFromForm ? expireFromForm : env.DEFAULT_EXPIRATION
 
   const uploadedParts = isMPUComplete ? (JSON.parse(contentAsString()) as R2UploadedPart[]) : undefined
@@ -195,6 +229,7 @@ export async function handlePostOrPut(
       passwd: newPasswd,
       contentLength: r2Object?.size || contentLength,
       filename,
+      filenames,
       highlightLanguage,
       encryptionScheme,
       isMPUComplete,
@@ -233,6 +268,7 @@ export async function handlePostOrPut(
       now,
       passwd: password,
       filename,
+      filenames,
       highlightLanguage,
       contentLength: r2Object?.size || contentLength,
       encryptionScheme,

--- a/worker/pages/display.ts
+++ b/worker/pages/display.ts
@@ -8,6 +8,7 @@ import { decode, escapeHtml } from "../common.js"
 import manifest from "../../dist/frontend/.vite/ssr-manifest.json"
 import { detectUtf8 } from "../../shared/encoding.js"
 import { getAssetPaths, renderCssLinks, DARK_MODE_SCRIPT, MAX_SSR_FILE_SIZE } from "../ssrUtils.js"
+import { filenameForTitle } from "../../shared/filename.js"
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer)
@@ -74,8 +75,10 @@ export async function renderDisplayPage(
 
   const inferredFilename = urlFilename || (urlExt && name + urlExt) || metadata.filename || name
   const pasteFile = new File([content], inferredFilename)
+  const displayName = metadata.filenames?.length ? `${metadata.filenames.length} files` : filenameForTitle(metadata.filename)
+  const titleUrlFilename = filenameForTitle(urlFilename)
   const titleName =
-    name + (urlFilename ? " / " + urlFilename : urlExt ? urlExt : metadata.filename ? " / " + metadata.filename : "")
+    name + (titleUrlFilename ? " / " + titleUrlFilename : urlExt ? urlExt : displayName ? " / " + displayName : "")
 
   const config: Env = {
     DEPLOY_URL: env.DEPLOY_URL,
@@ -104,6 +107,7 @@ export async function renderDisplayPage(
       ext: urlExt,
       filename: urlFilename,
       metaFilename: metadata.filename,
+      originalFiles: metadata.filenames,
       config,
     }),
   )
@@ -114,7 +118,7 @@ export async function renderDisplayPage(
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
-    html += decode(value.buffer as ArrayBuffer)
+    html += decode(value)
   }
 
   const { jsFile, cssPaths } = getAssetPaths(manifest, "display.html")

--- a/worker/pages/display.ts
+++ b/worker/pages/display.ts
@@ -9,6 +9,7 @@ import manifest from "../../dist/frontend/.vite/ssr-manifest.json"
 import { detectUtf8 } from "../../shared/encoding.js"
 import { getAssetPaths, renderCssLinks, DARK_MODE_SCRIPT, MAX_SSR_FILE_SIZE } from "../ssrUtils.js"
 import { filenameForTitle } from "../../shared/filename.js"
+import { itemCountLabel } from "../../shared/format.js"
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer)
@@ -75,7 +76,7 @@ export async function renderDisplayPage(
 
   const inferredFilename = urlFilename || (urlExt && name + urlExt) || metadata.filename || name
   const pasteFile = new File([content], inferredFilename)
-  const displayName = metadata.filenames?.length ? `${metadata.filenames.length} files` : filenameForTitle(metadata.filename)
+  const displayName = metadata.filenames?.length ? itemCountLabel(metadata.filenames.length) : filenameForTitle(metadata.filename)
   const titleUrlFilename = filenameForTitle(urlFilename)
   const titleName =
     name + (titleUrlFilename ? " / " + titleUrlFilename : urlExt ? urlExt : displayName ? " / " + displayName : "")
@@ -103,6 +104,7 @@ export async function renderDisplayPage(
         // SSR: no-op
       },
       isLoading: false,
+      isDownloading: false,
       name,
       ext: urlExt,
       filename: urlFilename,

--- a/worker/pages/display.ts
+++ b/worker/pages/display.ts
@@ -41,6 +41,7 @@ export async function renderDisplayPage(
   name: string,
   urlFilename: string | undefined,
   urlExt: string | undefined,
+  urlLang: string | undefined,
   paste: ArrayBuffer | ReadableStream<Uint8Array>,
   metadata: PasteMetadata,
 ): Promise<string | null> {
@@ -90,7 +91,7 @@ export async function renderDisplayPage(
     React.createElement(DisplayPasteView, {
       pasteFile,
       pasteContentBuffer: new Uint8Array(content),
-      pasteLang: metadata.highlightLanguage,
+      pasteLang: urlLang || metadata.highlightLanguage,
       isFileBinary: isBinary,
       guessedEncoding: encoding,
       isDecrypted: "not encrypted",
@@ -102,6 +103,7 @@ export async function renderDisplayPage(
       name,
       ext: urlExt,
       filename: urlFilename,
+      metaFilename: metadata.filename,
       config,
     }),
   )

--- a/worker/pages/index.ts
+++ b/worker/pages/index.ts
@@ -30,7 +30,7 @@ export async function renderIndexPage(env: Env, pathname: string): Promise<strin
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
-    html += decode(value.buffer as ArrayBuffer)
+    html += decode(value)
   }
 
   // Get resource paths from manifest

--- a/worker/storage/storage.ts
+++ b/worker/storage/storage.ts
@@ -20,6 +20,7 @@ export interface PasteMetadata {
   sizeBytes: number
   filename?: string
   filenames?: OriginalFileInfo[]
+  mimeType?: string
   highlightLanguage?: string
   encryptionScheme?: string
 }
@@ -37,6 +38,7 @@ interface PasteMetadataInStorage {
   sizeBytes?: number
   filename?: string
   filenames?: OriginalFileInfo[]
+  mimeType?: string
   highlightLanguage?: string
   encryptionScheme?: string
 }
@@ -50,6 +52,7 @@ export function metaResponseFromMetadata(metadata: PasteMetadata): MetaResponse 
     location: metadata.location,
     filename: metadata.filename,
     filenames: metadata.filenames,
+    mimeType: metadata.mimeType,
     highlightLanguage: metadata.highlightLanguage,
     encryptionScheme: metadata.encryptionScheme,
   }
@@ -69,6 +72,7 @@ function migratePasteMetadata(original: PasteMetadataInStorage): PasteMetadata {
     sizeBytes: original.sizeBytes || 0,
     filename: original.filename,
     filenames: original.filenames,
+    mimeType: original.mimeType,
     highlightLanguage: original.highlightLanguage,
     encryptionScheme: original.encryptionScheme,
   }
@@ -161,6 +165,7 @@ interface WriteOptions {
   passwd: string
   filename?: string
   filenames?: OriginalFileInfo[]
+  mimeType?: string
   highlightLanguage?: string
   encryptionScheme?: string
   isMPUComplete: boolean
@@ -194,6 +199,7 @@ export async function updatePaste(
     location: newLocation,
     filename: options.filename,
     filenames: options.filenames,
+    mimeType: options.mimeType,
     highlightLanguage: options.highlightLanguage,
     passwd: options.passwd,
 
@@ -236,6 +242,7 @@ export async function createPaste(
     location: location,
     filename: options.filename,
     filenames: options.filenames,
+    mimeType: options.mimeType,
     highlightLanguage: options.highlightLanguage,
     passwd: options.passwd,
 

--- a/worker/storage/storage.ts
+++ b/worker/storage/storage.ts
@@ -1,6 +1,6 @@
 import { dateToUnix, workerAssert, WorkerError } from "../common.js"
 import { parseSize } from "../../shared/parsers.js"
-import type { MetaResponse, PasteLocation } from "../../shared/interfaces.js"
+import type { MetaResponse, OriginalFileInfo, PasteLocation } from "../../shared/interfaces.js"
 
 // since CF does not allow expiration shorter than 60s, extend the expiration to 70s
 const PASTE_EXPIRE_SPECIFIED_MIN = 70
@@ -19,6 +19,7 @@ export interface PasteMetadata {
   accessCounter: number // a counter representing how frequent it is accessed, to administration usage
   sizeBytes: number
   filename?: string
+  filenames?: OriginalFileInfo[]
   highlightLanguage?: string
   encryptionScheme?: string
 }
@@ -35,6 +36,7 @@ interface PasteMetadataInStorage {
   accessCounter?: number
   sizeBytes?: number
   filename?: string
+  filenames?: OriginalFileInfo[]
   highlightLanguage?: string
   encryptionScheme?: string
 }
@@ -47,6 +49,7 @@ export function metaResponseFromMetadata(metadata: PasteMetadata): MetaResponse 
     sizeBytes: metadata.sizeBytes,
     location: metadata.location,
     filename: metadata.filename,
+    filenames: metadata.filenames,
     highlightLanguage: metadata.highlightLanguage,
     encryptionScheme: metadata.encryptionScheme,
   }
@@ -65,6 +68,7 @@ function migratePasteMetadata(original: PasteMetadataInStorage): PasteMetadata {
     accessCounter: original.accessCounter || 0,
     sizeBytes: original.sizeBytes || 0,
     filename: original.filename,
+    filenames: original.filenames,
     highlightLanguage: original.highlightLanguage,
     encryptionScheme: original.encryptionScheme,
   }
@@ -156,6 +160,7 @@ interface WriteOptions {
   expirationSeconds: number
   passwd: string
   filename?: string
+  filenames?: OriginalFileInfo[]
   highlightLanguage?: string
   encryptionScheme?: string
   isMPUComplete: boolean
@@ -188,6 +193,7 @@ export async function updatePaste(
     schemaVersion: 1,
     location: newLocation,
     filename: options.filename,
+    filenames: options.filenames,
     highlightLanguage: options.highlightLanguage,
     passwd: options.passwd,
 
@@ -229,6 +235,7 @@ export async function createPaste(
     schemaVersion: 1,
     location: location,
     filename: options.filename,
+    filenames: options.filenames,
     highlightLanguage: options.highlightLanguage,
     passwd: options.passwd,
 

--- a/worker/test/basic.spec.ts
+++ b/worker/test/basic.spec.ts
@@ -14,7 +14,7 @@ import {
   addRole,
 } from "./testUtils.js"
 import { createExecutionContext } from "cloudflare:test"
-import { DEFAULT_PASSWD_LEN, PASTE_NAME_LEN } from "../../shared/constants.js"
+import { DEFAULT_EDIT_FILENAME, DEFAULT_PASSWD_LEN, PASTE_NAME_LEN } from "../../shared/constants.js"
 import { parsePath } from "../../shared/parsers.js"
 
 describe("upload", () => {
@@ -158,6 +158,15 @@ test("GET special static pages", async () => {
     namedHtml.includes(`/ ${namedName} / song.mp3</title>`),
     `bare URL should include metadata filename`,
   ).toStrictEqual(true)
+
+  const untitledResp = await upload(ctx, { c: { content: genRandomBlob(1024), filename: DEFAULT_EDIT_FILENAME } })
+  const untitledName = parsePath(new URL(untitledResp.url).pathname).name
+  const untitledHtml = await (await workerFetch(ctx, `${BASE_URL}/d/${untitledName}`)).text()
+  expect(
+    untitledHtml.includes(`/ ${untitledName}</title>`),
+    `bare URL should hide the default metadata filename from the title`,
+  ).toStrictEqual(true)
+  expect(untitledHtml.includes(`/ ${untitledName} / ${DEFAULT_EDIT_FILENAME}</title>`)).toStrictEqual(false)
 
   // test manage page
   const manageUrl = resp.manageUrl

--- a/worker/test/controlHeaders.spec.ts
+++ b/worker/test/controlHeaders.spec.ts
@@ -1,20 +1,31 @@
 import { createExecutionContext, env } from "cloudflare:test"
 import { afterEach, beforeEach, expect, test, vi } from "vitest"
 
-import { BASE_URL, genRandomBlob, upload, workerFetch } from "./testUtils.js"
+import { addRole, BASE_URL, genRandomBlob, upload, workerFetch } from "./testUtils.js"
+import type { MetaResponse } from "../../shared/interfaces.js"
+import { BINARY_MIME_TYPE, TEXT_MIME_TYPE } from "../../shared/constants.js"
 
 test("mime type", async () => {
   const ctx = createExecutionContext()
-  const url = (await upload(ctx, { c: genRandomBlob(1024) })).url
+  const url = (await upload(ctx, { c: "hello" })).url
 
   const url_pic = (await upload(ctx, { c: { content: genRandomBlob(1024), filename: "xx.jpg" } })).url
+  const binaryUpload = await upload(ctx, {
+    c: { content: new Blob([new Uint8Array([1, 2, 0, 3])]), filename: "binary" },
+    mimeType: BINARY_MIME_TYPE,
+  })
+  const binaryUrl = binaryUpload.url
 
   async function testMime(accessUrl: string, mime: string) {
     const resp = await workerFetch(ctx, accessUrl)
     expect(resp.headers.get("Content-Type")).toStrictEqual(mime)
   }
 
-  await testMime(url, "text/plain;charset=UTF-8")
+  expect(binaryUpload.mimeType).toStrictEqual(BINARY_MIME_TYPE)
+  const binaryMeta: MetaResponse = await (await workerFetch(ctx, addRole(binaryUrl, "m"))).json()
+  expect(binaryMeta.mimeType).toStrictEqual(BINARY_MIME_TYPE)
+
+  await testMime(url, TEXT_MIME_TYPE)
   await testMime(`${url}.jpg`, "image/jpeg")
   await testMime(`${url}/test.jpg`, "image/jpeg")
   await testMime(`${url}?mime=random-mime`, "random-mime")
@@ -23,10 +34,11 @@ test("mime type", async () => {
 
   await testMime(url_pic, "image/jpeg")
   await testMime(`${url_pic}.png`, "image/png")
+  await testMime(binaryUrl, BINARY_MIME_TYPE)
 
   // test disallowed mimetypes
-  await testMime(`${url_pic}.html`, "text/plain;charset=UTF-8")
-  await testMime(`${url_pic}?mime=text/html`, "text/plain;charset=UTF-8")
+  await testMime(`${url_pic}.html`, TEXT_MIME_TYPE)
+  await testMime(`${url_pic}?mime=text/html`, TEXT_MIME_TYPE)
 })
 
 test("cache control", async () => {

--- a/worker/test/docPages.spec.ts
+++ b/worker/test/docPages.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { createExecutionContext } from "cloudflare:test"
 
 import { BASE_URL, workerFetch } from "./testUtils.js"
+import { TEXT_MIME_TYPE } from "../../shared/constants.js"
 
 const curlHeaders = { "User-Agent": "curl/8.0.0" }
 const browserHeaders = {
@@ -25,7 +26,7 @@ describe("doc pages", () => {
     for (const page of ["/doc/api", "/doc/tos", "/doc/curl", "/doc/skill"]) {
       const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: curlHeaders }))
       expect(resp.status, `visiting ${page}`).toStrictEqual(200)
-      expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+      expect(resp.headers.get("Content-Type")).toStrictEqual(TEXT_MIME_TYPE)
       expect(resp.headers.get("Vary")).toStrictEqual("User-Agent")
       const body = await resp.text()
       expect(body.startsWith("<!DOCTYPE html>"), `body of ${page} should be markdown`).toStrictEqual(false)
@@ -44,7 +45,7 @@ describe("doc pages", () => {
     for (const page of ["/doc/api.md", "/doc/tos.md", "/doc/curl.md", "/doc/skill.md"]) {
       const resp = await workerFetch(ctx, new Request(`${BASE_URL}${page}`, { headers: browserHeaders }))
       expect(resp.status, `visiting ${page}`).toStrictEqual(200)
-      expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+      expect(resp.headers.get("Content-Type")).toStrictEqual(TEXT_MIME_TYPE)
       const body = await resp.text()
       expect(body.startsWith("<!DOCTYPE html>"), `body of ${page} should be markdown`).toStrictEqual(false)
     }
@@ -53,7 +54,7 @@ describe("doc pages", () => {
   it("serves /index.md as markdown to any UA", async () => {
     const resp = await workerFetch(ctx, new Request(`${BASE_URL}/index.md`, { headers: browserHeaders }))
     expect(resp.status).toStrictEqual(200)
-    expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+    expect(resp.headers.get("Content-Type")).toStrictEqual(TEXT_MIME_TYPE)
     const body = await resp.text()
     expect(body.includes("# Pastebin Worker")).toStrictEqual(true)
     expect(body.includes("{{BASE_URL}}")).toStrictEqual(false)
@@ -69,7 +70,7 @@ describe("doc pages", () => {
   it("serves doc/index.md as markdown to curl on /", async () => {
     const resp = await workerFetch(ctx, new Request(BASE_URL, { headers: curlHeaders }))
     expect(resp.status).toStrictEqual(200)
-    expect(resp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+    expect(resp.headers.get("Content-Type")).toStrictEqual(TEXT_MIME_TYPE)
     expect(resp.headers.get("Vary")).toStrictEqual("User-Agent")
     const body = await resp.text()
     expect(body.includes("# Pastebin Worker"), "body should contain index heading").toStrictEqual(true)

--- a/worker/test/head.spec.ts
+++ b/worker/test/head.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, it, describe } from "vitest"
 import { addRole, genRandomBlob, upload, workerFetch } from "./testUtils.js"
 import { createExecutionContext } from "cloudflare:test"
+import { TEXT_MIME_TYPE } from "../../shared/constants.js"
 
 test("HEAD", async () => {
   const blob1 = genRandomBlob(1024)
@@ -17,10 +18,10 @@ test("HEAD", async () => {
     }),
   )
   expect(headResp.status).toStrictEqual(200)
-  expect(headResp.headers.get("Content-Type")).toStrictEqual("text/plain;charset=UTF-8")
+  expect(headResp.headers.get("Content-Type")).toStrictEqual(TEXT_MIME_TYPE)
   expect(headResp.headers.get("Content-Length")).toStrictEqual(blob1.size.toString())
   expect(headResp.headers.has("Last-Modified")).toStrictEqual(true)
-  expect(headResp.headers.get("Content-Disposition")).toStrictEqual("inline")
+  expect(headResp.headers.get("Content-Disposition")).toStrictEqual("inline; filename*=UTF-8''Untitled")
 
   // test head with filename and big blog
   const blob2 = genRandomBlob(1024 * 1024)

--- a/worker/test/ssr.spec.ts
+++ b/worker/test/ssr.spec.ts
@@ -20,6 +20,7 @@ describe("SSR Display Page", () => {
 
     // Should contain valid HTML structure
     expect(html).toContain("<!doctype html>")
+    expect(html.includes("\u0000")).toStrictEqual(false)
     expect(html).toContain('<div id="root">')
     expect(html).toContain(name) // Title should contain paste name
 

--- a/worker/test/testUtils.ts
+++ b/worker/test/testUtils.ts
@@ -5,6 +5,7 @@ import crypto from "crypto"
 
 import worker from "../index.js"
 import type { PasteResponse } from "../../shared/interfaces.js"
+import { DEFAULT_EDIT_FILENAME } from "../../shared/constants.js"
 
 export const BASE_URL: string = env.DEPLOY_URL
 export const RAND_NAME_REGEX = /^[ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678]+$/
@@ -102,7 +103,7 @@ export function createFormData(kv: FormDataBuild): FormData {
     if (typeof v === "string") {
       fd.set(k, v)
     } else if (v instanceof Blob) {
-      fd.set(k, v, "") // fd.set automatically set filename to k, not what we desired
+      fd.set(k, v, DEFAULT_EDIT_FILENAME) // fd.set automatically sets filename to k, not what we want for content.
     } else {
       // hack for typing
       const { content, filename } = v

--- a/worker/test/uploadOptions.spec.ts
+++ b/worker/test/uploadOptions.spec.ts
@@ -168,3 +168,34 @@ test("highlight with option lang", async () => {
   expect(getResp.headers.get("Access-Control-Expose-Headers")?.includes("X-PB-Highlight-Language")).toStrictEqual(true)
   expect(metaResp.highlightLanguage).toStrictEqual(lang)
 })
+
+test("filenames metadata", async () => {
+  const ctx = createExecutionContext()
+  const filenames = [
+    { name: "a.txt", sizeBytes: 3 },
+    { name: "b.bin", sizeBytes: 5 },
+  ]
+
+  const uploadResp = await upload(ctx, {
+    c: { content: genRandomBlob(8), filename: "paste-files-abc123.zip" },
+    filenames: JSON.stringify(filenames),
+  })
+
+  const metaResp: MetaResponse = await (await workerFetch(ctx, addRole(uploadResp.url, "m"))).json()
+  expect(uploadResp.filename).toStrictEqual("paste-files-abc123.zip")
+  expect(uploadResp.filenames).toStrictEqual(filenames)
+  expect(metaResp.filename).toStrictEqual("paste-files-abc123.zip")
+  expect(metaResp.filenames).toStrictEqual(filenames)
+})
+
+test("invalid filenames metadata", async () => {
+  const ctx = createExecutionContext()
+  await uploadExpectStatus(
+    ctx,
+    {
+      c: { content: genRandomBlob(8), filename: "paste-files-abc123.zip" },
+      filenames: JSON.stringify([{ name: "a.txt", sizeBytes: -1 }]),
+    },
+    400,
+  )
+})

--- a/worker/test/uploadOptions.spec.ts
+++ b/worker/test/uploadOptions.spec.ts
@@ -177,14 +177,14 @@ test("filenames metadata", async () => {
   ]
 
   const uploadResp = await upload(ctx, {
-    c: { content: genRandomBlob(8), filename: "paste-files-abc123.zip" },
+    c: { content: genRandomBlob(8), filename: "2-files-abc123.zip" },
     filenames: JSON.stringify(filenames),
   })
 
   const metaResp: MetaResponse = await (await workerFetch(ctx, addRole(uploadResp.url, "m"))).json()
-  expect(uploadResp.filename).toStrictEqual("paste-files-abc123.zip")
+  expect(uploadResp.filename).toStrictEqual("2-files-abc123.zip")
   expect(uploadResp.filenames).toStrictEqual(filenames)
-  expect(metaResp.filename).toStrictEqual("paste-files-abc123.zip")
+  expect(metaResp.filename).toStrictEqual("2-files-abc123.zip")
   expect(metaResp.filenames).toStrictEqual(filenames)
 })
 
@@ -193,7 +193,7 @@ test("invalid filenames metadata", async () => {
   await uploadExpectStatus(
     ctx,
     {
-      c: { content: genRandomBlob(8), filename: "paste-files-abc123.zip" },
+      c: { content: genRandomBlob(8), filename: "2-files-abc123.zip" },
       filenames: JSON.stringify([{ name: "a.txt", sizeBytes: -1 }]),
     },
     400,

--- a/worker/test/uploadOptions.spec.ts
+++ b/worker/test/uploadOptions.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "./testUtils.js"
 import { createExecutionContext, env } from "cloudflare:test"
 import type { MetaResponse } from "../../shared/interfaces.js"
-import { MAX_PASSWD_LEN, MIN_PASSWD_LEN, PRIVATE_PASTE_NAME_LEN } from "../../shared/constants.js"
+import { BINARY_MIME_TYPE, MAX_PASSWD_LEN, MIN_PASSWD_LEN, PRIVATE_PASTE_NAME_LEN } from "../../shared/constants.js"
 import { parseExpiration } from "../../shared/parsers.js"
 
 test("privacy url with option p", async () => {
@@ -128,7 +128,7 @@ test("encryption with option encryption-scheme", async () => {
 
   const fetchPaste = await workerFetch(ctx, url)
   await fetchPaste.bytes()
-  expect(fetchPaste.headers.get("Content-Type")).toStrictEqual("application/octet-stream")
+  expect(fetchPaste.headers.get("Content-Type")).toStrictEqual(BINARY_MIME_TYPE)
   expect(fetchPaste.headers.get("Content-Disposition")).toStrictEqual("inline; filename*=UTF-8''a.pdf.encrypted")
   expect(fetchPaste.headers.get("X-PB-Encryption-Scheme")).toStrictEqual("AES-GCM")
   expect(fetchPaste.headers.get("X-PB-Decrypted-Content-Type")).toStrictEqual("application/pdf")
@@ -162,6 +162,7 @@ test("highlight with option lang", async () => {
   const uploadResp = await upload(ctx, { c: blob1, lang: lang })
   const metaResp: MetaResponse = await (await workerFetch(ctx, addRole(uploadResp.url, "m"))).json()
   expect(metaResp.highlightLanguage).toStrictEqual(lang)
+  expect(metaResp.mimeType).toBeUndefined()
 
   const getResp = await workerFetch(ctx, uploadResp.url)
   expect(getResp.headers.get("X-PB-Highlight-Language")).toStrictEqual(lang)

--- a/worker/test/writeErrors.spec.ts
+++ b/worker/test/writeErrors.spec.ts
@@ -43,6 +43,29 @@ describe("write error paths — content/format validation", () => {
     expect(resp.status).toStrictEqual(413)
   })
 
+  it("POST accepts multipart body when final CRLF arrives as a separate chunk", async () => {
+    const fd = new FormData()
+    fd.set("c", new File(["x"], "split.txt"))
+    const sourceReq = new Request(BASE_URL, { method: "POST", body: fd })
+    const body = new Uint8Array(await sourceReq.arrayBuffer())
+    const splitAt = body.byteLength - 2
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(body.slice(0, splitAt))
+        controller.enqueue(body.slice(splitAt))
+        controller.close()
+      },
+    })
+    const splitRequestInit = {
+      method: "POST",
+      headers: { "Content-Type": sourceReq.headers.get("Content-Type")! },
+      body: stream,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" }
+    const resp = await worker.fetch(new Request(BASE_URL, splitRequestInit), env, ctx)
+    expect(resp.status).toStrictEqual(200)
+  })
+
   it("POST/PUT to an unknown /mpu/* path returns 400", async () => {
     const fd = new FormData()
     fd.set("c", new Blob(["x"]))


### PR DESCRIPTION
Add: multi file paste from clipboard and zip files and folders.
Add: edit has a default filename "Untitled" to avoid worker error.
Feat: user direct download file with client encrypt without ssr __PASTE_DATA__.
Add: sidebar for local uploads manage.
Add: direct show QR code of url.
Fix: drag and paste directory support.

SSR hydration mismatch cause website console error, fixed.

Paste file from clipboard is easy to use, also mulitple files is accepted, in frontend default zip for multi files. still has metadata for files list to display.

Rarely @mjackson/multipart-parser package cause a upload 400 error because of formdata boundary split of chunk coincidentally, so replace it with worker api request.formData(), with that api if user switch on client encryption with no filename edit would cause parse error, so we need a default edit file name which use "Untitled".

User may not much point need to download `.encrypted` file, so feat direct download decrypted raw file, need not load anyway.

For now, user can't manager history upload, so add a sidebar to manage local uploads.

Can show QR code of url so mobile device could scan QR.

Drag & drop and paste could support directory.
